### PR TITLE
Quarto setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 *.png
 *.pyc
 *.egg-info
+
+# quarto build artefacts
+.jupyter_cache
+*.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 /.quarto/
 
-_variables.yml
 *.DS_Store
 
 *.png

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -11,4 +11,4 @@ website:
       - about.qmd
   sidebar:
     search: true
-    contents: briefings/*.qmd
+    contents: briefings/*/*.qmd

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,21 @@
+name: wblib
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - aiohttp
+  - cartopy
+  - cmocean
+  - intake<2
+  - intake-xarray
+  - jupyter
+  - jupyter-cache
+  - matplotlib
+  - numpy
+  - nbformat
+  - requests
+  - xarray
+  - zarr
+  - pip
+  - pip:
+    - easygems

--- a/render_quarto.sh
+++ b/render_quarto.sh
@@ -1,10 +1,10 @@
 # render the final quarto file
+set -o xtrace
 
-briefing_date=${1}
+quarto_file=${1}
 quarto_command=${2:-preview}
 quarto_profile=${3:-slides}
 
-quarto_file=./briefings/${briefing_date}/main.qmd
 if [ ${quarto_command} = 'preview' ]; then
     quarto preview ${quarto_file} --no-navigate --profile ${quarto_profile}
 elif [ ${quarto_command} = 'render' ]; then


### PR DESCRIPTION
I modified the sidebar part of the _quarto.yaml file to match our new folder structure, which previously let quarto crash. Next, I added an environment.yaml file which we can add packages to as needed in the further development of this project. Last, I cleaned up the gitignore file which still included a file which is no longer in our file structure, and added two artefacts of the quarto build process (jupyter-cache and the jupyter notebook files that get created).