### PR TITLE
Removing unused catch_ignore_warn function

### DIFF
--- a/src/wblib/services/get_figures.py
+++ b/src/wblib/services/get_figures.py
@@ -55,13 +55,3 @@ def generate_internal_figures(current_time: pd.Timestamp,
 def _warn_function_is_not_defined(product, logger):
     msg = f"Undefined function for '{product}' product."
     logger(msg, "ERROR")
-
-
-def catch_ignore_warn(function, logger):
-    def wrap(*args, **kwargs):
-        try:
-            figure = function(*args, **kwargs)
-            logger(f"Ran figure function '{function.__name__}'", "INFO")
-            return figure
-        except:
-            logger(f"Ran figure function '{function.__name__}'", "INFO")


### PR DESCRIPTION
Removing the function catch_ignore_warn which is not used in the code, was not fully developed, and that I left in the code by mistake during the development of the module. 