### PR TITLE
Fix automated build

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -35,10 +35,11 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: 1.5.56
-      - name: Build slides
-        run: quarto render --profile slides
+      # Build website first as it wipes the "public/" directory!
       - name: Build website
         run: quarto render --profile website
+      - name: Build slides
+        run: quarto render --profile slides
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ this will check that all figures are complete and indicate possible missing ones
 
 After creating the briefing structure and all necessary figures, you can use quarto to build the presentations and website
 ```
-quarto render --profile slides
 quarto render --profile website
+quarto render --profile slides
 ```
 
 ### Preview Server


### PR DESCRIPTION
The "website" profile will wipe the "public/" directory (and slides within). As a workaround, build the website first and the slides afterwards.