### PR TITLE
Making the amount of previous forecasts loaded flexible.

### DIFF
--- a/src/wblib/figures/hifs.py
+++ b/src/wblib/figures/hifs.py
@@ -17,12 +17,12 @@ def get_latest_forecast_issue_time(briefing_time: pd.Timestamp):
     return issued_time
 
 
-def get_dates_of_N_previous_initializations(
+def get_dates_of_previous_initializations(
     issue_time: pd.Timestamp,
-    N_previous_forecasts: int=5,
+    number: int=5,
 ) -> list[pd.Timestamp]:
     day = pd.Timedelta("1D")
     dates = [(issue_time.floor("1D") - i * day) for i in
-             range(0, N_previous_forecasts)]
+             range(0, number)]
     dates.reverse()
     return dates

--- a/src/wblib/figures/hifs.py
+++ b/src/wblib/figures/hifs.py
@@ -17,10 +17,12 @@ def get_latest_forecast_issue_time(briefing_time: pd.Timestamp):
     return issued_time
 
 
-def get_dates_of_five_previous_initializations(
+def get_dates_of_N_previous_initializations(
     issue_time: pd.Timestamp,
+    N_previous_forecasts: int=5,
 ) -> list[pd.Timestamp]:
     day = pd.Timedelta("1D")
-    dates = [(issue_time.floor("1D") - i * day) for i in range(0, 5)]
+    dates = [(issue_time.floor("1D") - i * day) for i in
+             range(0, N_previous_forecasts)]
     dates.reverse()
     return dates

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -13,7 +13,7 @@ from matplotlib.figure import Figure
 import seaborn as sns
 
 from wblib.figures.hifs import get_latest_forecast_issue_time
-from wblib.figures.hifs import get_dates_of_N_previous_initializations
+from wblib.figures.hifs import get_dates_of_previous_initializations
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 ICWV_ITCZ_THRESHOLD = 48  # mm
@@ -36,7 +36,7 @@ REFDATE_LINEWIDTH = [1, 1.1, 1.2, 1.3, 1.5]
 def iwv_itcz_edges(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
     lead_delta = pd.Timedelta(hours=int(lead_hours[:-1]))
     issued_time = get_latest_forecast_issue_time(briefing_time)
-    issued_times = get_dates_of_N_previous_initializations(issued_time)
+    issued_times = get_dates_of_previous_initializations(issued_time)
     datarrays = _get_forecast_datarrays_dict(issued_times)
     # plot
     sns.set_context('talk')

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -13,7 +13,7 @@ from matplotlib.figure import Figure
 import seaborn as sns
 
 from wblib.figures.hifs import get_latest_forecast_issue_time
-from wblib.figures.hifs import get_dates_of_five_previous_initializations
+from wblib.figures.hifs import get_dates_of_N_previous_initializations
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 ICWV_ITCZ_THRESHOLD = 48  # mm
@@ -36,7 +36,7 @@ REFDATE_LINEWIDTH = [1, 1.1, 1.2, 1.3, 1.5]
 def iwv_itcz_edges(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
     lead_delta = pd.Timedelta(hours=int(lead_hours[:-1]))
     issued_time = get_latest_forecast_issue_time(briefing_time)
-    issued_times = get_dates_of_five_previous_initializations(issued_time)
+    issued_times = get_dates_of_N_previous_initializations(issued_time)
     datarrays = _get_forecast_datarrays_dict(issued_times)
     # plot
     sns.set_context('talk')


### PR DESCRIPTION
So far, the amount of previous forecasts loaded for plotting has been hard-coded to 5. With this pull request, the amount becomes flexible, but the default value is still set to 5 to not break running routines.