### PR TITLE
Define a default profile to build website and slides

### DIFF
--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -5,6 +5,8 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  # and on every pull request
+  pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -23,10 +25,7 @@ concurrency:
 
 jobs:
   # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -35,7 +34,6 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           version: 1.5.56
-      # Build website first as it wipes the "public/" directory!
       - name: Build website and slides
         run: quarto render
       - name: Setup Pages
@@ -43,8 +41,21 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
+          name: public
           path: 'public/'
+
+  deploy:
+    needs: build
+    if: "github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'orcestra-campaign'"
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download compiled book
+        uses: actions/download-artifact@v4
+        with:
+          name: public
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/static.yaml
+++ b/.github/workflows/static.yaml
@@ -36,10 +36,8 @@ jobs:
         with:
           version: 1.5.56
       # Build website first as it wipes the "public/" directory!
-      - name: Build website
-        run: quarto render --profile website
-      - name: Build slides
-        run: quarto render --profile slides
+      - name: Build website and slides
+        run: quarto render
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/README.md
+++ b/README.md
@@ -41,13 +41,12 @@ this will check that all figures are complete and indicate possible missing ones
 
 After creating the briefing structure and all necessary figures, you can use quarto to build the presentations and website
 ```
-quarto render --profile website
-quarto render --profile slides
+quarto render
 ```
 
 ### Preview Server
 
 You can also run quarto in preview mode, which will open a browser and navigate to the most recently modified file:
 ```
-quarto preview --profile slides
+quarto preview
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,9 @@ quarto render
 
 ### Preview Server
 
-You can also run quarto in preview mode, which will open a browser and navigate to the most recently modified file:
+You can also run quarto in preview mode, which will open a browser and navigate to the most recently modified file.
+Because all source files are built twice (in website and slide mode), the preview mechanism can get confused.
+Therefore, when working on a slide, it is best to explicitly run the preview server using the slide profile:
 ```
-quarto preview
+quarto preview --profile slides
 ```

--- a/_quarto-slides.yml
+++ b/_quarto-slides.yml
@@ -1,4 +1,5 @@
 project:
+  type: website
   output-dir: public/slides
   render:
     - "!index.qmd"

--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -1,5 +1,8 @@
 project:
+  type: website
   output-dir: public
+  post-render:
+    - quarto render --profile slides
 
 format:
   html:
@@ -9,3 +12,15 @@ format:
 
 filters:
   - path_meta.lua
+
+website:
+  title: "Weather"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+      - about.qmd
+  sidebar:
+    search: true
+    contents: briefings/*/*.qmd
+  margin-header: "{{< meta slide_link >}}"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -1,18 +1,8 @@
 project:
   type: website
-  output-dir: public
   render:
     - "*.qmd"
     - "!src/"
 
-website:
-  title: "Weather"
-  navbar:
-    left:
-      - href: index.qmd
-        text: Home
-      - about.qmd
-  sidebar:
-    search: true
-    contents: briefings/*/*.qmd
-  margin-header: "{{< meta slide_link >}}"
+profile:
+  default: website


### PR DESCRIPTION
This PR enables CI builds for pull requests and streamlines the build process by
1. More clearly separating the configuration for slides and website
2. Automatically building the slides as a post-processing step of the webiste
3. Defining the website as the default profile

As a result, the full website + slides can be build by running `quarto render`