### PR TITLE
show listing of newest briefings on index page

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -1,7 +1,11 @@
 ---
-title: "Weather"
+title: "ORCESTRA weather briefings"
+listing:
+  contents:
+    - "briefings/*/main.qmd"
+  type: grid
+  sort: date desc
+  fields: [image, description, date]
+  sort-ui: true
+  filter-ui: true
 ---
-
-This is a Quarto website.
-
-To learn more about Quarto websites visit <https://quarto.org/docs/websites>.


### PR DESCRIPTION
This change configures the index page of the website to use a grid-style listing of the available weather briefings.

See https://quarto.org/docs/websites/website-listings.html for more info about the listing feature.