### PR TITLE
Refactor figures

### DIFF
--- a/src/wblib/api/figures.py
+++ b/src/wblib/api/figures.py
@@ -20,24 +20,31 @@ def make_briefing_figures(date: str, logger: Callable = logger) -> None:
     # external
     external_location = variables_dict["location"]
     logger(f"External figure location set to {external_location}", "INFO")
-    external_time = pd.Timestamp.now(TIME_ZONE_STR)
-    logger(f"External figure time set to {external_time}", "INFO")
-    for product, image in generate_external_figures(external_location, external_time, logger):
+    current_time = pd.Timestamp.now(TIME_ZONE_STR)
+    logger(f"External figure time set to {current_time}", "INFO")
+    for product, image in generate_external_figures(
+        external_location, current_time, logger
+    ):
         fig_path = variables_dict["plots"]["external"][product]
         fig_path = get_briefing_path(date) + "/" + fig_path
         _save_image(image, fig_path)
         _close_image(image)
         logger(f"Saved external figure '{product}' in '{fig_path}'.", "INFO")
     # internal
-    internal_time = pd.Timestamp(date, tz=TIME_ZONE_STR)
-    logger(f"Internal figure time set to {internal_time}", "INFO")
-    for product, lead_time, image in generate_internal_figures(internal_time, logger):
+    briefing_time = pd.Timestamp(date, tz=TIME_ZONE_STR)
+    logger(f"Internal figure time set to {briefing_time}", "INFO")
+    for product, lead_time, image in generate_internal_figures(
+        briefing_time, current_time, logger
+    ):
         fig_path = variables_dict["plots"]["internal"][product][lead_time]
         fig_path = get_briefing_path(date) + "/" + fig_path
         _save_image(image, fig_path)
         _close_image(image)
-        logger(f"Saved internal figure '{product}' for '{internal_time}' "
-                f"and '{lead_time}' in '{fig_path}'.", "INFO")
+        logger(
+            f"Saved internal figure '{product}' for '{briefing_time}' "
+            f"and '{lead_time}' in '{fig_path}'.",
+            "INFO",
+        )
         _close_image(image)
 
 
@@ -61,7 +68,6 @@ def _close_image(image) -> None:
         return
     raise ValueError("Unrecognized figure type")
 
+
 if __name__ == "__main__":
     make_briefing_figures("20240731")  # for testing
-
-

--- a/src/wblib/api/figures.py
+++ b/src/wblib/api/figures.py
@@ -50,7 +50,6 @@ def make_briefing_figures(date: str, logger: Callable = logger) -> None:
 
 def _save_image(image, fig_path) -> None:
     if isinstance(image, Figure):
-        image.tight_layout()
         image.savefig(fig_path)
         return
     if isinstance(image, Image):

--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -39,7 +39,7 @@ def format_internal_figure_axes(
     annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
     ax.annotate(
         annotation,
-        (-25, -9),
+        (-28.5, -9),
         fontsize=8,
         bbox=dict(facecolor="white", edgecolor="none", alpha=1),
     )

--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -1,11 +1,6 @@
 """Functions to work with IFS forecasts in healpix format."""
 import pandas as pd
 
-
-FORECAST_PUBLISH_LAG = "8h"
-FORECAST_PUBLISH_FREQ = "12h"
-
-
 def get_valid_time(
     briefing_time: pd.Timestamp, briefing_lead_hours: str
 ) -> pd.Timestamp:
@@ -13,25 +8,3 @@ def get_valid_time(
     briefing_delta = pd.Timedelta(hours=int(briefing_lead_hours[:-1]))
     valid_time = briefing_time + briefing_delta
     return valid_time
-
-
-def get_latest_forecast_issue_time(briefing_time: pd.Timestamp):
-    current_time = pd.Timestamp.now("UTC")
-    publish_lag = pd.Timedelta(FORECAST_PUBLISH_LAG)
-    publish_freq = pd.Timedelta(FORECAST_PUBLISH_FREQ)
-    if current_time >= briefing_time + publish_lag:
-        issued_time = briefing_time
-    if current_time < briefing_time + publish_lag:
-        issued_time = current_time.floor(FORECAST_PUBLISH_FREQ) - publish_freq
-    return issued_time
-
-
-def get_dates_of_previous_initializations(
-    issue_time: pd.Timestamp,
-    number: int=5,
-) -> list[pd.Timestamp]:
-    day = pd.Timedelta("1D")
-    dates = [(issue_time.floor("1D") - i * day) for i in
-             range(0, number)]
-    dates.reverse()
-    return dates

--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -6,7 +6,7 @@ import cartopy.crs as ccrs
 
 ORCESTRA_DOMAIN = -65, -5, -10, 25  # lon_min, lon_max, lat_min, lat_max
 
-INTERNAL_FIGURE_SIZE = (15, 7)
+INTERNAL_FIGURE_SIZE = (15, 8)
 
 
 def get_valid_time(
@@ -39,7 +39,7 @@ def format_internal_figure_axes(
     annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
     ax.annotate(
         annotation,
-        (-28.5, -9),
+        (-26, -9),
         fontsize=8,
         bbox=dict(facecolor="white", edgecolor="none", alpha=1),
     )

--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -1,5 +1,13 @@
 """Functions to work with IFS forecasts in healpix format."""
+
+import numpy as np
 import pandas as pd
+import cartopy.crs as ccrs
+
+ORCESTRA_DOMAIN = -65, -5, -10, 25  # lon_min, lon_max, lat_min, lat_max
+
+INTERNAL_FIGURE_SIZE = (15, 7)
+
 
 def get_valid_time(
     briefing_time: pd.Timestamp, briefing_lead_hours: str
@@ -8,3 +16,30 @@ def get_valid_time(
     briefing_delta = pd.Timedelta(hours=int(briefing_lead_hours[:-1]))
     valid_time = briefing_time + briefing_delta
     return valid_time
+
+
+def format_internal_figure_axes(
+    briefing_time, lead_hours, issue_time, ax, crs=ccrs.PlateCarree()
+):
+    lon_min, lon_max, lat_min, lat_max = ORCESTRA_DOMAIN
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
+    title_str = (
+        f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')}UTC \n"
+        f"Lead hours: {lead_hours}"
+    )
+    ax.set_title(title_str)
+    ax.coastlines(lw=1.0, color="k")
+    ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=crs)
+    ax.set_yticks(np.round(np.linspace(-20, 20, 5), 0), crs=crs)
+    ax.set_ylabel("Latitude - \N{DEGREE SIGN}N")
+    ax.set_xlabel("Longitude - \N{DEGREE SIGN}E")
+    ax.set_xlim([lon_min, lon_max])
+    ax.set_ylim([lat_min, lat_max])
+    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
+    ax.annotate(
+        annotation,
+        (-25, -9),
+        fontsize=8,
+        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
+    )

--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -6,6 +6,15 @@ FORECAST_PUBLISH_LAG = "8h"
 FORECAST_PUBLISH_FREQ = "12h"
 
 
+def get_valid_time(
+    briefing_time: pd.Timestamp, briefing_lead_hours: str
+) -> pd.Timestamp:
+    """Valid time for when the briefing info applies."""
+    briefing_delta = pd.Timedelta(hours=int(briefing_lead_hours[:-1]))
+    valid_time = briefing_time + briefing_delta
+    return valid_time
+
+
 def get_latest_forecast_issue_time(briefing_time: pd.Timestamp):
     current_time = pd.Timestamp.now("UTC")
     publish_lag = pd.Timedelta(FORECAST_PUBLISH_LAG)

--- a/src/wblib/figures/external/ecmwf.py
+++ b/src/wblib/figures/external/ecmwf.py
@@ -3,57 +3,52 @@ from PIL import Image as img
 from io import BytesIO
 import pandas as pd
 
-from wblib.figures.hifs import get_latest_forecast_issue_time
 
 ANALYSIS_URLS = {
-    "IFS_meteogram": 'https://charts.ecmwf.int/opencharts-api/v1/products/opencharts_meteogram/',
+    "IFS_meteogram": "https://charts.ecmwf.int/opencharts-api/v1/products/opencharts_meteogram/",
 }
 
-def _create_params(location: str, issued_time: pd.Timestamp) -> dict:
-    coords = _get_coordinates(location)
-    params = {
-        'lat': coords[0],
-        'lon': coords[1],
-        'station_name': '',
-        'base_time': issued_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
-    }
-    return params
 
-
-def _get_coordinates(location: str) -> tuple:
-    if location == 'Sal':
-        lat = '16.73883'    #degN
-        lon = '-22.942'     #degE
-    elif location == 'Barbados':
-        lat = '13.075418'   #degN
-        lon = '-59.493768'  #degE
-    else:
-        error_str = ("Please provide a valid location. Valid locations are " +
-                     "currently: 'Sal' or 'Barbados'.")
-        raise ValueError(error_str)
-    return (lat, lon)
-
-
-def ifs_meteogram(location: str, briefing_time: pd.Timestamp) -> img.Image:
+def ifs_meteogram(current_time: pd.Timestamp, location: str) -> img.Image:
     url = ANALYSIS_URLS["IFS_meteogram"]
-    issued_time = get_latest_forecast_issue_time(briefing_time)
-    params = _create_params(location, issued_time)
+    params = _create_params(location)
     headers = {
-        'accept': 'application/json',
+        "accept": "application/json",
     }
-    
     response = requests.get(
         url,
         params=params,
         headers=headers,
     )
-
-    figure_url = response.json().get('data').get('link').get('href')
+    figure_url = response.json().get("data").get("link").get("href")
     response = requests.get(figure_url)
     image = img.open(BytesIO(response.content))
     return image
 
+
+def _create_params(location: str) -> dict:
+    coords = _get_coordinates(location)
+    params = {"lat": coords[0], "lon": coords[1], "station_name": ""}
+    return params
+
+
+def _get_coordinates(location: str) -> tuple:
+    if location == "Sal":
+        lat = "16.73883"  # degN
+        lon = "-22.942"  # degE
+    elif location == "Barbados":
+        lat = "13.075418"  # degN
+        lon = "-59.493768"  # degE
+    else:
+        error_str = (
+            "Please provide a valid location. Valid locations are "
+            + "currently: 'Sal' or 'Barbados'."
+        )
+        raise ValueError(error_str)
+    return (lat, lon)
+
+
 if __name__ == "__main__":
-    location = 'Sal'
-    briefing_time = pd.Timestamp("2024-08-05").tz_localize("UTC")
-    figure = ifs_meteogram(location, briefing_time)
+    location = "Sal"
+    current_time = pd.Timestamp("2024-08-07").tz_localize("UTC")
+    figure = ifs_meteogram(current_time, location)

--- a/src/wblib/figures/external/goes.py
+++ b/src/wblib/figures/external/goes.py
@@ -37,12 +37,12 @@ FIGURE_TITLES = {
 FIGURE_BOUNDARIES = (-70, 5, -10, 25)
 
 
-def current_satellite_image_vis(current_time: pd.Timestamp) -> Figure:
+def current_satellite_image_vis(current_time: pd.Timestamp, *args) -> Figure:
     fig = _get_satellite_image(current_time, "visible")
     return fig
 
 
-def current_satellite_image_ir(current_time: pd.Timestamp) -> Figure:
+def current_satellite_image_ir(current_time: pd.Timestamp, *args) -> Figure:
     fig = _get_satellite_image(current_time, "infrared")
     return fig
 

--- a/src/wblib/figures/hifs.py
+++ b/src/wblib/figures/hifs.py
@@ -1,0 +1,112 @@
+"""Functions to work with IFS forecasts in healpix format."""
+
+import copy
+from typing import Iterable
+import pandas as pd
+import xarray as xr
+import intake
+import easygems.healpix as egh
+
+from wblib.figures.briefing_info import get_valid_time
+
+
+FORECAST_PUBLISH_LAG = "8h"
+FORECAST_PUBLISH_FREQ = "12h"
+FORECAST_QUERY_MAX_ATTEMPS = 6  # last 6 initializations
+
+
+class HifsForecasts:
+    def __init__(self, catalog: intake.Catalog):
+        self.catalog = catalog
+
+    def get_forecast(
+        self,
+        variable: str,
+        briefing_time: pd.Timestamp,
+        lead_hours: str,
+        current_time: pd.Timestamp
+    ) -> tuple[pd.Timestamp, xr.DataArray]:
+        issue_time, forecast_dataset = _load_forecast_dataset(
+            briefing_time, current_time, self.catalog
+        )
+        valid_time = get_valid_time(briefing_time, lead_hours)
+        valid_time = valid_time.tz_localize(None)
+        forecast = forecast_dataset[variable].sel(time=valid_time)
+        return issue_time, forecast
+
+    def get_previous_forecasts(
+        self,
+        variable: str,
+        briefing_time: pd.Timestamp,
+        lead_hours: str,
+        current_time: pd.Timestamp,
+        number: int = 5,
+    ) -> Iterable[tuple[pd.Timestamp, xr.DataArray]]:
+        valid_time = get_valid_time(briefing_time, lead_hours)
+        valid_time = valid_time.tz_localize(None)
+        briefing_times = _get_dates_of_previous_briefings(
+            briefing_time, number
+        )
+        for briefing_time in briefing_times:
+            issue_time, forecast_dataset = _load_forecast_dataset(
+                briefing_time, current_time, self.catalog
+            )
+            forecast = forecast_dataset[variable].sel(time=valid_time)
+            yield issue_time, forecast
+
+
+def _load_forecast_dataset(
+    briefing_time: pd.Timestamp,
+    current_time: pd.Timestamp,
+    catalog: intake.Catalog,
+) -> tuple[pd.Timestamp, xr.Dataset]:
+    publish_freq = pd.Timedelta(FORECAST_PUBLISH_FREQ)
+    query_forecast_attempts = FORECAST_QUERY_MAX_ATTEMPS
+    issue_time = _expected_issue_time(briefing_time, current_time)
+    while query_forecast_attempts:
+        try:
+            forecast = (
+                catalog.HIFS(
+                    refdate=issue_time.strftime("%Y-%m-%d"),
+                    reftime=issue_time.strftime("%H"),
+                )
+                .to_dask()
+                .pipe(egh.attach_coords)
+            )
+            return issue_time, forecast
+        except KeyError:
+            query_forecast_attempts -= 1
+            issue_time = issue_time - publish_freq
+    msg = f"No forecasts available for brifieng_time '{briefing_time}'."
+    raise KeyError(msg)
+
+
+def _expected_issue_time(
+    briefing_time: pd.Timestamp, current_time: pd.Timestamp
+) -> pd.Timestamp:
+    if current_time >= briefing_time:
+        return copy.deepcopy(briefing_time)
+    else:
+        return current_time.floor(FORECAST_PUBLISH_FREQ)
+
+
+def _get_dates_of_previous_briefings(
+    briefing_time: pd.Timestamp,
+    number: int = 5,
+) -> list[pd.Timestamp]:
+    day = pd.Timedelta("1D")
+    dates = [(briefing_time.floor("1D") - i * day) for i in range(0, number)]
+    dates.reverse()
+    return dates
+
+
+if __name__ == "__main__":
+    import intake
+
+    CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+    incatalog = intake.open_catalog(CATALOG_URL)
+    hifs = HifsForecasts(incatalog)
+    briefing_time1 = pd.Timestamp(2024, 8, 7).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
+
+    hifs.get_forecast('tp', briefing_time1, "108H", current_time1)

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -12,8 +12,8 @@ from matplotlib.figure import Figure
 
 import seaborn as sns
 
-from wblib.figures.hifs import get_latest_forecast_issue_time
-from wblib.figures.hifs import get_dates_of_previous_initializations
+from wblib.figures.briefing_info import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_dates_of_previous_initializations
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 ICWV_ITCZ_THRESHOLD = 48  # mm

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -53,7 +53,7 @@ def iwv_itcz_edges(
     format_internal_figure_axes(briefing_time, lead_hours, issue_time, ax)
     _draw_icwv_contours_for_previous_forecasts(forecasts, ax)
     im = _draw_icwv_current_forecast(forecast, ax)
-    fig.colorbar(im, label="IWV / kg m$^{-2}$", shrink=0.8)
+    fig.colorbar(im, label="IWV - kg m$^{-2}$", shrink=0.8)
     matplotlib.rc_file_defaults()
     return fig
 

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -12,7 +12,8 @@ from matplotlib.figure import Figure
 
 import seaborn as sns
 
-from wblib.figures.briefing_info import get_valid_time
+from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
+from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 
 
@@ -21,8 +22,6 @@ ICWV_MAX = 65  # mm
 ICWV_MIN = 0  # mm
 ICWV_COLORMAP = "bone"
 ICWV_CATALOG_VARIABLE = "tcwv"
-FIGURE_SIZE = (15, 8)
-FIGURE_BOUNDARIES = (-70, 10, -10, 30)
 REFDATE_COLORBAR = [
     "#ffc99d",
     "#ffa472",
@@ -48,13 +47,13 @@ def iwv_itcz_edges(
     # plot
     sns.set_context("talk")
     fig, ax = plt.subplots(
-        figsize=FIGURE_SIZE,
+        figsize=INTERNAL_FIGURE_SIZE,
         subplot_kw={"projection": ccrs.PlateCarree()}
     )
-    _format_axes(briefing_time, lead_hours, issue_time, ax)
+    format_internal_figure_axes(briefing_time, lead_hours, issue_time, ax)
     _draw_icwv_contours_for_previous_forecasts(forecasts, ax)
     im = _draw_icwv_current_forecast(forecast, ax)
-    fig.colorbar(im, label="IWV / kg m$^{-2}$", shrink=0.7)
+    fig.colorbar(im, label="IWV / kg m$^{-2}$", shrink=0.8)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -84,34 +83,6 @@ def _draw_icwv_current_forecast(forecast, ax):
     return im
 
 
-def _format_axes(briefing_time, lead_hours, issued_time, ax):
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    ax.set_extent(
-        [lon_min, lon_max, lat_min, lat_max]
-    )  # need this line here to get the contours and lines on the plot
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    valid_time = get_valid_time(briefing_time, lead_hours)
-    title_str = (
-        f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')} \n"
-        f"Lead hours: {lead_hours}"
-    )
-    ax.set_title(title_str)
-    ax.coastlines(lw=1.0, color="k")
-    ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=ccrs.PlateCarree())
-    ax.set_yticks(np.round(np.linspace(-20, 20, 5), 0), crs=ccrs.PlateCarree())
-    ax.set_ylabel("Latitude \N{DEGREE SIGN}N")
-    ax.set_xlabel("Longitude \N{DEGREE SIGN}E")
-    ax.set_xlim([lon_min, lon_max])
-    ax.set_ylim([lat_min, lat_max])
-    annotation = f"Latest ECMWF IFS forecast initialization: {issued_time.strftime('%Y-%m-%d %H:%M %Z')}"
-    ax.annotate(
-        annotation,
-        (-21.25, -9),
-        fontsize=8,
-        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
-    )
-
-
 if __name__ == "__main__":
     import intake
 
@@ -121,4 +92,6 @@ if __name__ == "__main__":
     briefing_time1 = pd.Timestamp(2024, 8, 7).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
 
-    iwv_itcz_edges(briefing_time1, "003H", current_time1, hifs)
+    fig = iwv_itcz_edges(briefing_time1, "003H", current_time1, hifs)
+    fig.tight_layout()
+    fig.savefig("test2.png")

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -18,9 +18,9 @@ from wblib.figures.hifs import HifsForecasts
 
 
 ICWV_ITCZ_THRESHOLD = 48  # mm
-ICWV_MAX = 65  # mm
-ICWV_MIN = 0  # mm
-ICWV_COLORMAP = "bone"
+ICWV_MAX = 70  # mm
+ICWV_MIN = 45  # mm
+ICWV_COLORMAP = "Blues"
 ICWV_CATALOG_VARIABLE = "tcwv"
 REFDATE_COLORBAR = [
     "#ffc99d",
@@ -76,6 +76,7 @@ def _draw_icwv_current_forecast(forecast, ax):
         forecast,
         ax=ax,
         method="linear",
+        alpha=0.75,
         cmap=ICWV_COLORMAP,
         vmin=ICWV_MIN,
         vmax=ICWV_MAX,
@@ -93,5 +94,4 @@ if __name__ == "__main__":
     current_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
 
     fig = iwv_itcz_edges(briefing_time1, "003H", current_time1, hifs)
-    fig.tight_layout()
-    fig.savefig("test2.png")
+    fig

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -11,10 +11,9 @@ import matplotlib.colors as mcolors
 import seaborn as sns
 import easygems.healpix as egh
 
-from wblib.figures.briefing_info import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_valid_time
+from wblib.figures.hifs import HifsForecasts
 
-
-CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 CATALOG_OLR_CODE = "ttr"
 CATALOG_ICWV_CODE = "tcwv"
 
@@ -29,76 +28,47 @@ FIGURE_BOUNDARIES = (-70, 10, -10, 30)
 
 
 def toa_outgoing_longwave(
-    briefing_time: pd.Timestamp, lead_hours: str, *args, **kwargs
+    briefing_time: pd.Timestamp,
+    lead_hours: str,
+    current_time: pd.Timestamp,
+    hifs: HifsForecasts,
 ) -> Figure:
-    lead_delta = pd.Timedelta(hours=int(lead_hours[:-1]))
-    issued_time = get_latest_forecast_issue_time(briefing_time)
-    valid_time = briefing_time + lead_delta
-    catalog = intake.open_catalog(CATALOG_URL)
-    accumulated_ttr = _get_forecast_datarray(
-        catalog, issued_time, CATALOG_OLR_CODE
+    issue_time, diff_ttr = hifs.get_forecast(
+        CATALOG_OLR_CODE,
+        briefing_time,
+        lead_hours,
+        current_time,
+        differentiate=True,
+        differentiate_unit="s",
     )
-    icwv = _get_forecast_datarray(catalog, issued_time, CATALOG_ICWV_CODE)
-    olr = _convert_accumulated_ttr_to_olr(accumulated_ttr, issued_time)
-    olr = olr.sel(time=valid_time.tz_localize(None))
-    icwv = icwv.sel(time=valid_time.tz_localize(None))
+    olr = - diff_ttr
+    _, icwv = hifs.get_forecast(
+        CATALOG_ICWV_CODE, briefing_time, lead_hours, current_time
+    )
     # plot
     sns.set_context("talk")
     fig, ax = plt.subplots(
         figsize=FIGURE_SIZE, subplot_kw={"projection": ccrs.PlateCarree()}
     )
+    _format_axes(briefing_time, lead_hours, issue_time, ax)
     _draw_olr(olr, fig, ax)
     _draw_icwv_contour(icwv, ax)
-    _format_axes(valid_time, issued_time, lead_delta, ax)
     matplotlib.rc_file_defaults()
     return fig
 
 
-def _get_forecast_datarray(
-    catalog, issued_time: pd.Timestamp, variable: str
-) -> xr.DataArray:
-    refdate = issued_time.strftime("%Y-%m-%d")
-    dataset = catalog.HIFS(refdate=refdate).to_dask().pipe(egh.attach_coords)
-    datarray = dataset[variable]
-    return datarray
-
-
-def _convert_accumulated_ttr_to_olr(
-    accumulated_ttr: xr.DataArray, issued_time: pd.Timestamp
-) -> xr.DataArray:
-    olr = xr.zeros_like(accumulated_ttr)
-    for i, time in enumerate(accumulated_ttr.time.values):
-        if i == 0:
-            previous_time = issued_time
-            timedelta = pd.Timedelta(time - issued_time.tz_localize(None))
-            ttr_0 = -accumulated_ttr.loc[dict(time=time)]
-            olr.loc[dict(time=time)] = ttr_0 / timedelta.total_seconds()
-            continue
-        previous_time = accumulated_ttr.time.values[i - 1]
-        timedelta = pd.Timedelta(time - previous_time)
-        ttr_2 = -accumulated_ttr.loc[dict(time=time)]
-        ttr_1 = -accumulated_ttr.loc[dict(time=time - timedelta)]
-        olr.loc[dict(time=time)] = (ttr_2 - ttr_1) / timedelta.total_seconds()
-    return olr
-
-
 def _draw_olr(olr, fig, ax) -> None:
-    sns.set_context("talk")
     # get_orl_colormap
-    gist_ncar = plt.cm.gist_ncar_r(np.linspace(0.0, 1, 128))
+    gist_ncar = plt.cm.Spectral(np.linspace(0.0, 1, 128))
     white = np.array([1.0, 1.0, 1.0, 1.0])
     colors = np.vstack((gist_ncar, white))
     colormap = mcolors.LinearSegmentedColormap.from_list("olr", colors)
     # draw plot
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
-    ax.coastlines(lw=0.8)
     im = egh.healpix_show(
         olr, method="linear", cmap=colormap, vmin=OLR_MIN, vmax=OLR_MAX, ax=ax
     )
     # format colorbar
     fig.colorbar(im, label="OLR $W/m^2$", shrink=0.7)
-    matplotlib.rc_file_defaults()
 
 
 def _draw_icwv_contour(icwv, ax):
@@ -111,16 +81,20 @@ def _draw_icwv_contour(icwv, ax):
         levels=[ICWV_ITCZ_THRESHOLD],
         colors=color,
         linewidths=2,
-        linestyles = 'dashed'
+        linestyles="dashed",
     )
-    format_func = lambda level : f"{int(level)} mm"
+    format_func = lambda level: f"{int(level)} mm"
     ax.clabel(hcs, hcs.levels, inline=True, fontsize=10, fmt=format_func)
 
-def _format_axes(valid_time, issued_time, lead_delta, ax):
+
+def _format_axes(briefing_time, lead_hours, issue_time, ax):
     lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
+    ax.coastlines(lw=0.8)
     title_str = (
         f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')} \n"
-        f"Lead hours: {int(lead_delta.total_seconds() / 3600):03d}"
+        f"Lead hours: {lead_hours}"
     )
     ax.set_title(title_str)
     ax.coastlines(lw=1.0, color="k")
@@ -130,10 +104,22 @@ def _format_axes(valid_time, issued_time, lead_delta, ax):
     ax.set_xlabel("Longitude \N{DEGREE SIGN}E")
     ax.set_xlim([lon_min, lon_max])
     ax.set_ylim([lat_min, lat_max])
-    annotation = f"Latest ECMWF IFS forecast initialization: {issued_time.strftime('%Y-%m-%d %H:%M %Z')}"
+    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
     ax.annotate(
         annotation,
         (-21.25, -9),
         fontsize=8,
         bbox=dict(facecolor="white", edgecolor="none", alpha=1),
     )
+
+
+if __name__ == "__main__":
+    import intake
+
+    CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+    incatalog = intake.open_catalog(CATALOG_URL)
+    hifs = HifsForecasts(incatalog)
+    briefing_time1 = pd.Timestamp(2024, 8, 1).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 1, 11).tz_localize("UTC")
+
+    toa_outgoing_longwave(briefing_time1, "003H", current_time1, hifs)

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -58,20 +58,22 @@ def toa_outgoing_longwave(
 
 def _draw_olr(olr, fig, ax) -> None:
     # get_orl_colormap
-    gist_ncar = plt.cm.Spectral(np.linspace(0.0, 1, 128))
+    spectral = plt.cm.Spectral(np.linspace(0.0, 1, 9))
     white = np.array([1.0, 1.0, 1.0, 1.0])
-    colors = np.vstack((gist_ncar, white))
-    colormap = mcolors.LinearSegmentedColormap.from_list("olr", colors)
+    colors = np.vstack((spectral, white))
+    colormap = mcolors.ListedColormap(colors, "olr")
     # draw plot
     im = egh.healpix_show(
         olr, method="linear", cmap=colormap, vmin=OLR_MIN, vmax=OLR_MAX, ax=ax
     )
     # format colorbar
-    fig.colorbar(im, label="OLR $W/m^2$", shrink=0.8)
+    fig.colorbar(im,
+                 label="OLR $W/m^2$",
+                 ticks=np.linspace(OLR_MIN, OLR_MAX, 11),
+                 shrink=0.8)
 
 
 def _draw_icwv_contour(icwv, ax):
-    color = ICWV_COLOR
     hcs = egh.healpix_contour(
         icwv,
         ax=ax,

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -11,7 +11,8 @@ import matplotlib.colors as mcolors
 import seaborn as sns
 import easygems.healpix as egh
 
-from wblib.figures.briefing_info import get_valid_time
+from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
+from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 
 CATALOG_OLR_CODE = "ttr"
@@ -22,9 +23,6 @@ ICWV_COLOR = "dimgrey"
 
 OLR_MAX = 250
 OLR_MIN = 100
-
-FIGURE_SIZE = (15, 8)
-FIGURE_BOUNDARIES = (-70, 10, -10, 30)
 
 
 def toa_outgoing_longwave(
@@ -41,16 +39,17 @@ def toa_outgoing_longwave(
         differentiate=True,
         differentiate_unit="s",
     )
-    olr = - diff_ttr
+    olr = -diff_ttr
     _, icwv = hifs.get_forecast(
         CATALOG_ICWV_CODE, briefing_time, lead_hours, current_time
     )
     # plot
     sns.set_context("talk")
     fig, ax = plt.subplots(
-        figsize=FIGURE_SIZE, subplot_kw={"projection": ccrs.PlateCarree()}
+        figsize=INTERNAL_FIGURE_SIZE,
+        subplot_kw={"projection": ccrs.PlateCarree()},
     )
-    _format_axes(briefing_time, lead_hours, issue_time, ax)
+    format_internal_figure_axes(briefing_time, lead_hours, issue_time, ax)
     _draw_olr(olr, fig, ax)
     _draw_icwv_contour(icwv, ax)
     matplotlib.rc_file_defaults()
@@ -68,49 +67,21 @@ def _draw_olr(olr, fig, ax) -> None:
         olr, method="linear", cmap=colormap, vmin=OLR_MIN, vmax=OLR_MAX, ax=ax
     )
     # format colorbar
-    fig.colorbar(im, label="OLR $W/m^2$", shrink=0.7)
+    fig.colorbar(im, label="OLR $W/m^2$", shrink=0.8)
 
 
 def _draw_icwv_contour(icwv, ax):
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
     color = ICWV_COLOR
     hcs = egh.healpix_contour(
         icwv,
         ax=ax,
         levels=[ICWV_ITCZ_THRESHOLD],
-        colors=color,
+        colors=ICWV_COLOR,
         linewidths=2,
         linestyles="dashed",
     )
     format_func = lambda level: f"{int(level)} mm"
     ax.clabel(hcs, hcs.levels, inline=True, fontsize=10, fmt=format_func)
-
-
-def _format_axes(briefing_time, lead_hours, issue_time, ax):
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    valid_time = get_valid_time(briefing_time, lead_hours)
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
-    ax.coastlines(lw=0.8)
-    title_str = (
-        f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')} \n"
-        f"Lead hours: {lead_hours}"
-    )
-    ax.set_title(title_str)
-    ax.coastlines(lw=1.0, color="k")
-    ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=ccrs.PlateCarree())
-    ax.set_yticks(np.round(np.linspace(-20, 20, 5), 0), crs=ccrs.PlateCarree())
-    ax.set_ylabel("Latitude \N{DEGREE SIGN}N")
-    ax.set_xlabel("Longitude \N{DEGREE SIGN}E")
-    ax.set_xlim([lon_min, lon_max])
-    ax.set_ylim([lat_min, lat_max])
-    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
-    ax.annotate(
-        annotation,
-        (-21.25, -9),
-        fontsize=8,
-        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
-    )
 
 
 if __name__ == "__main__":

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -11,7 +11,7 @@ import matplotlib.colors as mcolors
 import seaborn as sns
 import easygems.healpix as egh
 
-from wblib.figures.hifs import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_latest_forecast_issue_time
 
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -16,15 +16,15 @@ import seaborn as sns
 import cmocean as cmo
 
 from wblib.figures.hifs import HifsForecasts
-from wblib.figures.briefing_info import get_valid_time
+from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
+from wblib.figures.briefing_info import format_internal_figure_axes
+
 
 TP_THRESHOLD = 50  # mm
 TCWV_THRESHOLD = 48  # mm
 TP_STEPS = [0, 5, 25, 50, 75, 100]
 TP_COLORMAP = cmo.cm.rain
 DATA_CATALOG_VARIABLE = ["tp", "tcwv"]
-FIGURE_SIZE = (15, 8)
-DOMAIN = "Sal"
 REFDATE_COLORBAR_TP = [
     "#ff7e26",
     "#ff580f",
@@ -34,7 +34,6 @@ REFDATE_COLORBAR_TCWV = [
     "royalblue",
 ]
 REFDATE_LINEWIDTH = [1.0, 1.4]
-FIGURE_BOUNDARIES = (-70, 10, -10, 30)
 
 
 def precip(
@@ -75,9 +74,10 @@ def precip(
     # plotting
     sns.set_context("talk")
     fig, ax = plt.subplots(
-        figsize=FIGURE_SIZE, subplot_kw={"projection": ccrs.PlateCarree()}
+        figsize=INTERNAL_FIGURE_SIZE,
+        subplot_kw={"projection": ccrs.PlateCarree()}
     )
-    _format_axes(briefing_time, lead_hours, issue_time, ax)
+    format_internal_figure_axes(briefing_time, lead_hours, issue_time, ax)
     _draw_tp_contours_for_previous_forecasts(precip_forecasts, ax)
     _draw_tcwv_contours_for_previous_forecasts(tcwv_forecasts, ax)
     _draw_current_forecast(precip, fig, ax)
@@ -124,32 +124,7 @@ def _draw_current_forecast(precip, fig, ax):
         norm=BoundaryNorm(TP_STEPS, ncolors=TP_COLORMAP.N, clip=True),
         cmap=TP_COLORMAP,
     )
-    fig.colorbar(im, label="mean precip. rate / mm day$^{-1}$", shrink=0.7)
-
-
-def _format_axes(briefing_time, lead_hours, issue_time, ax):
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    valid_time = get_valid_time(briefing_time, lead_hours)
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
-    title_str = (
-        f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')}UTC \n"
-        f"Lead hours: {lead_hours}"
-    )
-    ax.set_title(title_str)
-    ax.coastlines(lw=1.0, color="k")
-    ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=ccrs.PlateCarree())
-    ax.set_yticks(np.round(np.linspace(-20, 20, 5), 0), crs=ccrs.PlateCarree())
-    ax.set_ylabel("Latitude / \N{DEGREE SIGN}N")
-    ax.set_xlabel("Longitude / \N{DEGREE SIGN}E")
-    ax.set_xlim([lon_min, lon_max])
-    ax.set_ylim([lat_min, lat_max])
-    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
-    ax.annotate(
-        annotation,
-        (-21.25, -9),
-        fontsize=8,
-        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
-    )
+    fig.colorbar(im, label="mean precip. rate / mm day$^{-1}$", shrink=0.8)
 
 
 def _add_legend(init_times: list, **kwargs):

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -15,20 +15,16 @@ from matplotlib.colors import BoundaryNorm
 import seaborn as sns
 import cmocean as cmo
 
-#import orcestra.sat
-#from wblib.figures.internal._general_plotting_functions import plot_sattrack
+from wblib.figures.hifs import HifsForecasts
+from wblib.figures.briefing_info import get_valid_time
 
-from wblib.figures.briefing_info import get_latest_forecast_issue_time
-from wblib.figures.briefing_info import get_dates_of_previous_initializations
-
-CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 TP_THRESHOLD = 50  # mm
-TCWV_THRESHOLD = 48 # mm
+TCWV_THRESHOLD = 48  # mm
 TP_STEPS = [0, 5, 25, 50, 75, 100]
 TP_COLORMAP = cmo.cm.rain
 DATA_CATALOG_VARIABLE = ["tp", "tcwv"]
 FIGURE_SIZE = (15, 8)
-DOMAIN = 'Sal'
+DOMAIN = "Sal"
 REFDATE_COLORBAR_TP = [
     "#ff7e26",
     "#ff580f",
@@ -38,132 +34,107 @@ REFDATE_COLORBAR_TCWV = [
     "royalblue",
 ]
 REFDATE_LINEWIDTH = [1.0, 1.4]
+FIGURE_BOUNDARIES = (-70, 10, -10, 30)
 
-def precip(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
+
+def precip(
+    briefing_time: pd.Timestamp,
+    lead_hours: str,
+    current_time: pd.Timestamp,
+    hifs: HifsForecasts,
+) -> Figure:
     # retrieve the forecast data
-    lead_delta = pd.Timedelta(hours=int(lead_hours[:-1]))
-    issued_time = get_latest_forecast_issue_time(briefing_time)
-    issued_times = get_dates_of_previous_initializations(issued_time, number=2)
-    datarrays = _get_forecast_datarrays_dict(issued_times)
-    precip = {init_time: datarrays[init_time]['tp'] for init_time in
-              issued_times}
-    tcwv = {init_time: datarrays[init_time]['tcwv'] for init_time in
-            issued_times}
-    for init_time in issued_times:
-        precip[init_time] = precip[init_time].differentiate(
-            'time', datetime_unit='D') * 1000
-
+    issue_time, precip = hifs.get_forecast(
+        DATA_CATALOG_VARIABLE[0],
+        briefing_time,
+        lead_hours,
+        current_time,
+        differentiate=True,
+        differentiate_unit="D",
+    )
+    precip = 1000 * precip
+    precip_forecasts = hifs.get_previous_forecasts(
+        DATA_CATALOG_VARIABLE[0],
+        briefing_time,
+        lead_hours,
+        current_time,
+        number=2,
+        differentiate=True,
+        differentiate_unit="D",
+    )
+    precip_forecasts = (
+        (issue_time, 1000 * precip) for issue_time, precip in precip_forecasts
+    )
+    tcwv_forecasts = hifs.get_previous_forecasts(
+        DATA_CATALOG_VARIABLE[1],
+        briefing_time,
+        lead_hours,
+        current_time,
+        number=2,
+    )
     # plotting
-    sns.set_context('talk')
+    sns.set_context("talk")
     fig, ax = plt.subplots(
         figsize=FIGURE_SIZE, subplot_kw={"projection": ccrs.PlateCarree()}
     )
-    _draw_tp_contours_for_previous_forecasts(
-        precip, briefing_time, lead_delta, issued_times, ax
-    )
-    _draw_tcwv_contours_for_previous_forecasts(
-        tcwv, briefing_time, lead_delta, issued_times, ax
-    )
-    im = _draw_current_forecast(
-        precip, briefing_time, lead_delta, issued_times, ax
-    )
-    #plot_sattrack(valid_time, ax)
-    _format_axes(briefing_time, lead_delta, ax)
-    _add_legend(issued_times, loc='lower right')
-    fig.colorbar(im, label="mean precip. rate / mm day$^{-1}$",
-                 shrink=0.7)
+    _format_axes(briefing_time, lead_hours, issue_time, ax)
+    _draw_tp_contours_for_previous_forecasts(precip_forecasts, ax)
+    _draw_tcwv_contours_for_previous_forecasts(tcwv_forecasts, ax)
+    _draw_current_forecast(precip, fig, ax)
     matplotlib.rc_file_defaults()
     return fig
 
-def _select_latlonbox(domain: str) -> tuple:
-    if domain == 'full_Atlantic':
-        return (-70, 10, -10, 30)
-    elif domain == 'Sal':
-        return (-50, 0, -5, 20)
-    elif domain == 'Barbados':
-        return (-70, 10, -10, 30)
-    else:
-        raise ValueError ('Please provide a valid domain! Valid domains are:' +
-                          ' "full_Atlantic", "Sal", and "Barbados".')
 
-
-def _get_forecast_datarrays_dict(init_times):
-    catalog = intake.open_catalog(CATALOG_URL)
-    datarrays = dict()
-    for init_time in init_times:
-        refdate = init_time.strftime("%Y-%m-%d")
-        dataset = (
-            catalog.HIFS(refdate=refdate).to_dask().pipe(egh.attach_coords)
-        )
-        datarrays[init_time] = dataset[DATA_CATALOG_VARIABLE]
-    return datarrays
-
-def _draw_tp_contours_for_previous_forecasts(
-    datarrays, briefing_time, lead_delta, init_times, ax
-):
-    lon_min, lon_max, lat_min, lat_max = _select_latlonbox(DOMAIN)
-    ax.set_extent(
-        [lon_min, lon_max, lat_min, lat_max]
-    )  # need this line here to get the contours and lines on the plot
-    for i, init_time in enumerate(init_times):
+def _draw_tp_contours_for_previous_forecasts(precip_forecasts, ax):
+    for i, (_, precip) in enumerate(precip_forecasts):
         color = REFDATE_COLORBAR_TP[i]
         linewidth = REFDATE_LINEWIDTH[i]
-        valid_time = briefing_time + lead_delta
-        valid_time = valid_time.tz_localize(None)
-        field = datarrays[init_time].sel(time=valid_time)
-        im = egh.healpix_contour(
-            field,
+        egh.healpix_contour(
+            precip,
             ax=ax,
             levels=[TP_THRESHOLD],
             colors=color,
             linewidths=linewidth,
         )
 
-def _draw_tcwv_contours_for_previous_forecasts(
-    datarrays, briefing_time, lead_delta, init_times, ax
-):
-    lon_min, lon_max, lat_min, lat_max = _select_latlonbox(DOMAIN)
-    ax.set_extent(
-        [lon_min, lon_max, lat_min, lat_max]
-    )  # need this line here to get the contours and lines on the plot
-    for i, init_time in enumerate(init_times):
+
+def _draw_tcwv_contours_for_previous_forecasts(tcwv_forecasts, ax):
+    issued_times = []
+    for i, (issued_time_, tcwv_forecasts) in enumerate(tcwv_forecasts):
         color = REFDATE_COLORBAR_TCWV[i]
         linewidth = REFDATE_LINEWIDTH[i]
-        valid_time = briefing_time + lead_delta
-        valid_time = valid_time.tz_localize(None)
-        field = datarrays[init_time].sel(time=valid_time)
         im = egh.healpix_contour(
-            field,
+            tcwv_forecasts,
             ax=ax,
             levels=[TCWV_THRESHOLD],
-            linestyles = '--',
+            linestyles="--",
             colors=color,
             linewidths=linewidth,
         )
         ax.clabel(im, inline=True, fontsize=10)
+        issued_times.append(issued_time_)
+    _add_legend(issued_times, loc="lower left")
 
-def _draw_current_forecast(
-    datarrays, briefing_time, lead_delta, init_times, ax
-):
-    valid_time = briefing_time + lead_delta
-    valid_time = valid_time.tz_localize(None)
-    field = datarrays[init_times[-1]].sel(time=valid_time)
+
+def _draw_current_forecast(precip, fig, ax):
     im = egh.healpix_show(
-        field,
+        precip,
         ax=ax,
         method="linear",
-        norm = BoundaryNorm(TP_STEPS, ncolors=TP_COLORMAP.N, clip=True),
+        norm=BoundaryNorm(TP_STEPS, ncolors=TP_COLORMAP.N, clip=True),
         cmap=TP_COLORMAP,
     )
-    return im
+    fig.colorbar(im, label="mean precip. rate / mm day$^{-1}$", shrink=0.7)
 
-def _format_axes(briefing_time, lead_delta, ax):
-    lon_min, lon_max, lat_min, lat_max = _select_latlonbox(DOMAIN)
-    valid_time = briefing_time + lead_delta
+
+def _format_axes(briefing_time, lead_hours, issue_time, ax):
+    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
     title_str = (
         f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')}UTC \n"
-        f"Lead hours: {int(lead_delta.total_seconds() / 3600):03d}"
-                 )
+        f"Lead hours: {lead_hours}"
+    )
     ax.set_title(title_str)
     ax.coastlines(lw=1.0, color="k")
     ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=ccrs.PlateCarree())
@@ -172,18 +143,40 @@ def _format_axes(briefing_time, lead_delta, ax):
     ax.set_xlabel("Longitude / \N{DEGREE SIGN}E")
     ax.set_xlim([lon_min, lon_max])
     ax.set_ylim([lat_min, lat_max])
+    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
+    ax.annotate(
+        annotation,
+        (-21.25, -9),
+        fontsize=8,
+        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
+    )
+
 
 def _add_legend(init_times: list, **kwargs):
-    lines = [Line2D([0], [0],
-                    color=REFDATE_COLORBAR_TP[i],
-                    linewidth=REFDATE_LINEWIDTH[i],
-                    linestyle='-') for i in range(len(init_times)-1, -1, -1)]
-    labels = [f'init: {init_time.strftime("%Y-%m-%d %H:%M")}UTC' for
-              init_time in init_times[::-1]]
+    lines = [
+        Line2D(
+            [0],
+            [0],
+            color=REFDATE_COLORBAR_TP[i],
+            linewidth=REFDATE_LINEWIDTH[i],
+            linestyle="-",
+        )
+        for i in range(len(init_times) - 1, -1, -1)
+    ]
+    labels = [
+        f'init: {init_time.strftime("%Y-%m-%d %H:%M")}UTC'
+        for init_time in init_times[::-1]
+    ]
     plt.legend(lines, labels, **kwargs, fontsize=12)
 
+
 if __name__ == "__main__":
-    briefing_time = pd.Timestamp("2024-07-31").tz_localize("UTC")
-    lead_hours_str = "12H"
-    figure = precip(briefing_time, lead_hours_str)
-    figure.savefig("test.png")
+    import intake
+
+    CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+    incatalog = intake.open_catalog(CATALOG_URL)
+    hifs = HifsForecasts(incatalog)
+    briefing_time1 = pd.Timestamp(2024, 8, 1).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 1, 11).tz_localize("UTC")
+
+    precip(briefing_time1, "003H", current_time1, hifs)

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -18,8 +18,8 @@ import cmocean as cmo
 #import orcestra.sat
 #from wblib.figures.internal._general_plotting_functions import plot_sattrack
 
-from wblib.figures.hifs import get_latest_forecast_issue_time
-from wblib.figures.hifs import get_dates_of_previous_initializations
+from wblib.figures.briefing_info import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_dates_of_previous_initializations
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 TP_THRESHOLD = 50  # mm
@@ -52,7 +52,7 @@ def precip(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
     for init_time in issued_times:
         precip[init_time] = precip[init_time].differentiate(
             'time', datetime_unit='D') * 1000
-    
+
     # plotting
     sns.set_context('talk')
     fig, ax = plt.subplots(
@@ -86,7 +86,7 @@ def _select_latlonbox(domain: str) -> tuple:
         raise ValueError ('Please provide a valid domain! Valid domains are:' +
                           ' "full_Atlantic", "Sal", and "Barbados".')
 
- 
+
 def _get_forecast_datarrays_dict(init_times):
     catalog = intake.open_catalog(CATALOG_URL)
     datarrays = dict()
@@ -141,7 +141,7 @@ def _draw_tcwv_contours_for_previous_forecasts(
             linewidths=linewidth,
         )
         ax.clabel(im, inline=True, fontsize=10)
-        
+
 def _draw_current_forecast(
     datarrays, briefing_time, lead_delta, init_times, ax
 ):

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -124,7 +124,7 @@ def _draw_current_forecast(precip, fig, ax):
         norm=BoundaryNorm(TP_STEPS, ncolors=TP_COLORMAP.N, clip=True),
         cmap=TP_COLORMAP,
     )
-    fig.colorbar(im, label="mean precip. rate / mm day$^{-1}$", shrink=0.8)
+    fig.colorbar(im, label="mean precip. rate - mm day$^{-1}$", shrink=0.8)
 
 
 def _add_legend(init_times: list, **kwargs):

--- a/src/wblib/figures/internal/sfc_wind_quivers.py
+++ b/src/wblib/figures/internal/sfc_wind_quivers.py
@@ -12,9 +12,10 @@ import seaborn as sns
 import healpy as hp
 import xarray as xr
 
-from wblib.figures.briefing_info import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_valid_time
+from wblib.figures.hifs import HifsForecasts
 
-CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+
 FORECAST_PUBLISH_LAG = "6h"
 SPEED_THRESHOLD = 3  # m/s
 SPEED_MAX = 15  # m/s
@@ -25,74 +26,129 @@ FIGURE_BOUNDARIES = (-65, -5, -10, 20)
 MESH_GRID_SIZE = 50
 QUIVER_SKIP = 4
 
-def sfc_wind_quivers(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
-    lead_delta = pd.Timedelta(hours=int(lead_hours[:-1]))
-    issued_time = get_latest_forecast_issue_time(briefing_time)
-    refdate = issued_time.strftime("%Y-%m-%d")
-    cat = intake.open_catalog(CATALOG_URL)
-    ds = cat['HIFS'](refdate=refdate).to_dask().pipe(egh.attach_coords)
-    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
 
-    windspeed_10m = np.sqrt(ds['10u']**2 + ds['10v']**2)
-    lon1 = np.linspace(lon_min, lon_max, MESH_GRID_SIZE)
-    lat1 = np.linspace(lat_min, lat_max, MESH_GRID_SIZE)
-    pix = xr.DataArray(
-        hp.ang2pix(ds.crs.healpix_nside, *np.meshgrid(lon1, lat1), nest=True, lonlat=True),
-        coords=(("lat1", lat1), ("lon1", lon1)),
+def sfc_wind_quivers(
+    briefing_time: pd.Timestamp,
+    lead_hours: str,
+    current_time: pd.Timestamp,
+    hifs: HifsForecasts,
+) -> Figure:
+    issue_time, u10m = hifs.get_forecast(
+        "10u", briefing_time, lead_hours, current_time
     )
-    valid_time = briefing_time + lead_delta
-    valid_time = valid_time.tz_localize(None)
-
+    _, v10m = hifs.get_forecast("10v", briefing_time, lead_hours, current_time)
+    windspeed_10m = np.sqrt(u10m**2 + v10m**2)
     # plotting
-    sns.set_context('talk')
-    fig, ax = plt.subplots(figsize=FIGURE_SIZE, subplot_kw={"projection": ccrs.PlateCarree()}, facecolor='white')
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
-    ax.coastlines(lw=0.8)
-    # filled contours
-    im1 = egh.healpix_show(
-        windspeed_10m.sel(time=valid_time),
+    sns.set_context("talk")
+    fig, ax = plt.subplots(
+        figsize=FIGURE_SIZE,
+        subplot_kw={"projection": ccrs.PlateCarree()},
+        facecolor="white",
+    )
+    _speed_format_axes(briefing_time, lead_hours, issue_time, ax)
+    _windspeed_plot(windspeed_10m, fig, ax)
+    _wind_direction_plot(u10m, v10m, ax)
+    _windspeed_contour(windspeed_10m, ax)
+    matplotlib.rc_file_defaults()
+    return fig
+
+
+def _windspeed_contour(windspeed_10m, ax):
+    im = egh.healpix_contour(
+        windspeed_10m,
+        ax=ax,
+        levels=[SPEED_THRESHOLD],
+        colors="r",
+    )
+    ax.clabel(im, inline=True, fontsize=12, colors="r", fmt="%d")
+
+
+def _windspeed_plot(windspeed_10m, fig, ax):
+    im = egh.healpix_show(
+        windspeed_10m,
         method="linear",
         cmap=SPEED_COLORMAP,
         vmin=SPEED_MIN,
         vmax=SPEED_MAX,
+        ax=ax,
     )
-    # quiver plot
-    Q0 = ax.quiver(lon1[::QUIVER_SKIP], lat1[::QUIVER_SKIP], ds['10u'].sel(time=valid_time).isel(cell = pix)[::QUIVER_SKIP, ::QUIVER_SKIP]
-                   , ds['10v'].sel(time = valid_time).isel(cell = pix)[::QUIVER_SKIP, ::QUIVER_SKIP]
-                   , color = 'black', pivot = 'middle', scale_units = 'inches', width = 0.003, scale = 20)
-    ax.quiverkey(Q0, 0.95, 1.02, 10, r'$10 \frac{m}{s}$', labelpos='E', coordinates='axes', animated=True)
-    # 3 m/s wind speed contour
-    im2 = egh.healpix_contour(windspeed_10m.sel(time=valid_time), ax = ax,
-            levels = [SPEED_THRESHOLD], colors = 'r'
-            )
-    # axes formatting
-    fig.colorbar(im1, label = '10m wind speed / m s$^{-1}$', shrink = 0.8)
-    plt.clabel(im2, inline=True, fontsize=12, colors='r', fmt="%d")
-    _speed_format_axes(briefing_time, issued_time, lead_delta, ax)
-    matplotlib.rc_file_defaults()
-    return fig
+    fig.colorbar(im, label="10m wind speed / m s$^{-1}$", shrink=0.8)
 
-def _speed_format_axes(briefing_time, issued_time, lead_delta, ax):
+
+def _wind_direction_plot(u10m, v10m, ax):
     lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-    valid_time = briefing_time + lead_delta
+    lon1 = np.linspace(lon_min, lon_max, MESH_GRID_SIZE)
+    lat1 = np.linspace(lat_min, lat_max, MESH_GRID_SIZE)
+    pix = xr.DataArray(
+        hp.ang2pix(
+            u10m.crs.healpix_nside,
+            *np.meshgrid(lon1, lat1),
+            nest=True,
+            lonlat=True,
+        ),
+        coords=(("lat1", lat1), ("lon1", lon1)),
+    )
+    Q0 = ax.quiver(
+        lon1[::QUIVER_SKIP],
+        lat1[::QUIVER_SKIP],
+        u10m.isel(cell=pix)[::QUIVER_SKIP, ::QUIVER_SKIP],
+        v10m.isel(cell=pix)[::QUIVER_SKIP, ::QUIVER_SKIP],
+        color="black",
+        pivot="middle",
+        scale_units="inches",
+        width=0.003,
+        scale=20,
+    )
+    ax.quiverkey(
+        Q0,
+        0.95,
+        1.05,
+        10,
+        r"$10 \frac{m}{s}$",
+        labelpos="E",
+        coordinates="axes",
+        animated=True,
+    )
+
+
+def _speed_format_axes(briefing_time, lead_hours, issue_time, ax):
+    lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    ax.set_extent([lon_min, lon_max, lat_min, lat_max])
+    ax.coastlines(lw=0.8)
     title_str = (
-            f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')} \n"
-            f"Lead hours: {int(lead_delta.total_seconds() / 3600):03d}"
-                     )
+        f"Valid time: {valid_time.strftime('%Y-%m-%d %H:%M')} \n"
+        f"Lead hours: {lead_hours}"
+    )
     ax.set_title(title_str)
     ax.coastlines(lw=1.0, color="k")
-    ax.set_xticks(np.round(np.linspace(lon_min+5, lon_max-5, 6),0), crs=ccrs.PlateCarree())
-    ax.set_yticks(np.round(np.linspace(lat_min, lat_max, 5),0), crs=ccrs.PlateCarree())
+    ax.set_xticks(
+        np.round(np.linspace(lon_min + 5, lon_max - 5, 6), 0),
+        crs=ccrs.PlateCarree(),
+    )
+    ax.set_yticks(
+        np.round(np.linspace(lat_min, lat_max, 5), 0), crs=ccrs.PlateCarree()
+    )
     ax.set_ylabel("Latitude \N{DEGREE SIGN}N")
     ax.set_xlabel("Longitude \N{DEGREE SIGN}E")
     ax.set_xlim([lon_min, lon_max])
     ax.set_ylim([lat_min, lat_max])
-    annotation = f"Latest ECMWF IFS forecast initialization: {issued_time.strftime('%Y-%m-%d %H:%M %Z')}"
-    ax.annotate(annotation,
-                (-32.25, -9),
-                fontsize=8,
-                bbox = dict(facecolor='white',
-                            edgecolor='none',
-                            alpha=1))
+    annotation = f"Latest ECMWF IFS forecast initialization: {issue_time.strftime('%Y-%m-%d %H:%M %Z')}"
+    ax.annotate(
+        annotation,
+        (-32.25, -9),
+        fontsize=8,
+        bbox=dict(facecolor="white", edgecolor="none", alpha=1),
+    )
 
 
+if __name__ == "__main__":
+    import intake
+
+    CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+    incatalog = intake.open_catalog(CATALOG_URL)
+    hifs = HifsForecasts(incatalog)
+    briefing_time1 = pd.Timestamp(2024, 8, 1).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 1, 11).tz_localize("UTC")
+
+    sfc_wind_quivers(briefing_time1, "003H", current_time1, hifs)

--- a/src/wblib/figures/internal/sfc_wind_quivers.py
+++ b/src/wblib/figures/internal/sfc_wind_quivers.py
@@ -12,7 +12,7 @@ import seaborn as sns
 import healpy as hp
 import xarray as xr
 
-from wblib.figures.hifs import get_latest_forecast_issue_time
+from wblib.figures.briefing_info import get_latest_forecast_issue_time
 
 CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
 FORECAST_PUBLISH_LAG = "6h"
@@ -32,7 +32,7 @@ def sfc_wind_quivers(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
     cat = intake.open_catalog(CATALOG_URL)
     ds = cat['HIFS'](refdate=refdate).to_dask().pipe(egh.attach_coords)
     lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
-   
+
     windspeed_10m = np.sqrt(ds['10u']**2 + ds['10v']**2)
     lon1 = np.linspace(lon_min, lon_max, MESH_GRID_SIZE)
     lat1 = np.linspace(lat_min, lat_max, MESH_GRID_SIZE)
@@ -55,14 +55,14 @@ def sfc_wind_quivers(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
         cmap=SPEED_COLORMAP,
         vmin=SPEED_MIN,
         vmax=SPEED_MAX,
-    )   
+    )
     # quiver plot
     Q0 = ax.quiver(lon1[::QUIVER_SKIP], lat1[::QUIVER_SKIP], ds['10u'].sel(time=valid_time).isel(cell = pix)[::QUIVER_SKIP, ::QUIVER_SKIP]
                    , ds['10v'].sel(time = valid_time).isel(cell = pix)[::QUIVER_SKIP, ::QUIVER_SKIP]
-                   , color = 'black', pivot = 'middle', scale_units = 'inches', width = 0.003, scale = 20) 
+                   , color = 'black', pivot = 'middle', scale_units = 'inches', width = 0.003, scale = 20)
     ax.quiverkey(Q0, 0.95, 1.02, 10, r'$10 \frac{m}{s}$', labelpos='E', coordinates='axes', animated=True)
     # 3 m/s wind speed contour
-    im2 = egh.healpix_contour(windspeed_10m.sel(time=valid_time), ax = ax, 
+    im2 = egh.healpix_contour(windspeed_10m.sel(time=valid_time), ax = ax,
             levels = [SPEED_THRESHOLD], colors = 'r'
             )
     # axes formatting
@@ -71,7 +71,7 @@ def sfc_wind_quivers(briefing_time: pd.Timestamp, lead_hours: str) -> Figure:
     _speed_format_axes(briefing_time, issued_time, lead_delta, ax)
     matplotlib.rc_file_defaults()
     return fig
-    
+
 def _speed_format_axes(briefing_time, issued_time, lead_delta, ax):
     lon_min, lon_max, lat_min, lat_max = FIGURE_BOUNDARIES
     valid_time = briefing_time + lead_delta
@@ -82,7 +82,7 @@ def _speed_format_axes(briefing_time, issued_time, lead_delta, ax):
     ax.set_title(title_str)
     ax.coastlines(lw=1.0, color="k")
     ax.set_xticks(np.round(np.linspace(lon_min+5, lon_max-5, 6),0), crs=ccrs.PlateCarree())
-    ax.set_yticks(np.round(np.linspace(lat_min, lat_max, 5),0), crs=ccrs.PlateCarree()) 
+    ax.set_yticks(np.round(np.linspace(lat_min, lat_max, 5),0), crs=ccrs.PlateCarree())
     ax.set_ylabel("Latitude \N{DEGREE SIGN}N")
     ax.set_xlabel("Longitude \N{DEGREE SIGN}E")
     ax.set_xlim([lon_min, lon_max])
@@ -94,5 +94,5 @@ def _speed_format_axes(briefing_time, issued_time, lead_delta, ax):
                 bbox = dict(facecolor='white',
                             edgecolor='none',
                             alpha=1))
-    
+
 

--- a/src/wblib/figures/internal/sfc_winds.py
+++ b/src/wblib/figures/internal/sfc_winds.py
@@ -27,7 +27,7 @@ MESH_GRID_SIZE = 50
 QUIVER_SKIP = 4
 
 
-def sfc_wind_quivers(
+def sfc_winds(
     briefing_time: pd.Timestamp,
     lead_hours: str,
     current_time: pd.Timestamp,
@@ -151,4 +151,4 @@ if __name__ == "__main__":
     briefing_time1 = pd.Timestamp(2024, 8, 1).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 1, 11).tz_localize("UTC")
 
-    sfc_wind_quivers(briefing_time1, "003H", current_time1, hifs)
+    sfc_winds(briefing_time1, "003H", current_time1, hifs)

--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -7,7 +7,7 @@ from wblib.figures.external.noaa import nhc_seven_days_outlook
 from wblib.figures.external.noaa import nhc_surface_analysis_atlantic
 from wblib.figures.external.ecmwf import ifs_meteogram
 from wblib.figures.internal.icwv import iwv_itcz_edges
-from wblib.figures.internal.sfc_wind_quivers import sfc_wind_quivers
+from wblib.figures.internal.sfc_winds import sfc_winds
 from wblib.figures.internal.precip import precip
 from wblib.figures.internal.olr import toa_outgoing_longwave
 
@@ -23,7 +23,7 @@ EXTERNAL_PLOTS = {
 
 INTERNAL_PLOTS = {
     "iwv_itcz_edges": iwv_itcz_edges,
-    "surface_wind_quivers": sfc_wind_quivers,
+    "sfc_winds": sfc_winds,
     "precip": precip,
     "toa_outgoing_longwave": toa_outgoing_longwave
 }

--- a/src/wblib/services/get_figures.py
+++ b/src/wblib/services/get_figures.py
@@ -52,6 +52,7 @@ def generate_internal_figures(
                 figure = function(
                     briefing_time, lead_hours, current_time, hifs
                 )
+                figure.tight_layout(pad=1.01)
                 yield (product, lead_hours, figure)
             except Exception as error:
                 msg = (
@@ -67,3 +68,11 @@ def generate_internal_figures(
 def _warn_function_is_not_defined(product, logger):
     msg = f"Undefined function for '{product}' product."
     logger(msg, "ERROR")
+
+if __name__ == "__main__":
+    def logger(message: str, level: str) -> None:
+        return None
+    briefing_time1 = pd.Timestamp(2024, 8, 7).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
+    figures = generate_internal_figures(briefing_time1, current_time1, logger)
+    next(figures)

--- a/src/wblib/services/get_figures.py
+++ b/src/wblib/services/get_figures.py
@@ -23,10 +23,7 @@ def generate_external_figures(
             _warn_function_is_not_defined(product, logger)
             continue
         try:
-            if product == 'ifs_meteogram':
-                figure = function(current_location, current_time)
-            else:
-                figure = function(current_time)
+            figure = function(current_time, current_location)
             yield (product, figure)
         except Exception as error:
             msg = (

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -9,7 +9,7 @@ title: "PERCUSION Weather briefing"
 ## NHC tropical weather outlook
 ![]({{< meta plots.external.nhc_seven_days_outlook >}})
 
-## 
+##
 :::: {.columns}
 ::: {.column width="30%"}
 ### NHC tropical Hovmöller
@@ -46,34 +46,24 @@ title: "PERCUSION Weather briefing"
 ## Integrated Water Vapor Forecast
 ![]({{< meta plots.internal.iwv_itcz_edges.108h >}})
 
-##
-:::: {.columns}
-::: {.column width="30%"}
-### Local forecast for {{< meta location >}}
-:::
-::: {.column width="70%"}
-![]({{< meta plots.external.ifs_meteogram >}}){width="61%"}
-:::
-::::
-
 # ECMWF 10m Surface Wind Speed
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.003h >}})
+![]({{< meta plots.internal.sfc_winds.003h >}})
 
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.012h >}})
+![]({{< meta plots.internal.sfc_winds.012h >}})
 
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.036h >}})
+![]({{< meta plots.internal.sfc_winds.036h >}})
 
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.060h >}})
+![]({{< meta plots.internal.sfc_winds.060h >}})
 
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.084h >}})
+![]({{< meta plots.internal.sfc_winds.084h >}})
 
 ## 10m surface wind speed forecast
-![]({{< meta plots.internal.surface_wind_quivers.108h >}})
+![]({{< meta plots.internal.sfc_winds.108h >}})
 
 # ECMWF Outgoing Longwave Radiation
 ## Outgoing Longwave Radiation Forecast
@@ -113,6 +103,15 @@ title: "PERCUSION Weather briefing"
 ## Precipitation Forecast
 ![]({{< meta plots.internal.precip.108h >}})
 
+##
+:::: {.columns}
+::: {.column width="30%"}
+### Local forecast for {{< meta location >}}
+:::
+::: {.column width="70%"}
+![]({{< meta plots.external.ifs_meteogram >}}){width="61%"}
+:::
+::::
 
 
 ## Summary


### PR DESCRIPTION
This solves #44. It refactor the internal and external functions, and also makes changes that have been recently discussed.

The main refactoring of the external functions are the following:
- Decoupled ecmwf.py from hifs.py. In tests made not passing "base_time" to the ECMWF API return the latest available. This should be preferable. 
- Now all external figures receive current time and location information.

The main refactoring of the internal functions are the following:
- Added class HifsForecasts that manages access to IFS forecast data. It also manages getting instantaneous values from accumulated ones.
- Added module briefing_info.py with definition of valid date and a method to format axes for all internal figures.
- Refactored internal figure functions to use the new classes and methods.
- Refactored the interface of the internal figures.

The main changes in the internal functions are the following:
- Adjusted domain of plots making it common for all.
- Adjusted colormap of plot with lattes comments. 