### PR TITLE
Removing 3h lead forecast and visible satellite image from wblib workflow

### DIFF
--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -27,4 +27,4 @@ INTERNAL_PLOTS = {
     "precip": precip,
     "toa_outgoing_longwave": toa_outgoing_longwave
 }
-INTERNAL_PLOTS_LEADTIMES = ["003h", "012h", "036h", "060h", "084h", "108h"]
+INTERNAL_PLOTS_LEADTIMES = ["012h", "036h", "060h", "084h", "108h"]

--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -15,7 +15,6 @@ from wblib.figures.internal.olr import toa_outgoing_longwave
 EXTERNAL_PLOTS = {
     "nhc_surface_analysis_atlantic": nhc_surface_analysis_atlantic,
     "nhc_seven_days_outlook": nhc_seven_days_outlook,
-    "current_satellite_image_vis": current_satellite_image_vis,
     "current_satellite_image_ir": current_satellite_image_ir,
     "nhc_hovmoller": nhc_hovmoller,
     "ifs_meteogram": ifs_meteogram,

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -24,12 +24,8 @@ title: "PERCUSION Weather briefing"
 ## GOES WEST Latest Infrared Image
 ![]({{< meta plots.external.current_satellite_image_ir >}})
 
-## GOES WEST Latest Visible Image
-![]({{< meta plots.external.current_satellite_image_vis >}})
 
 # ECMWF Integrated Water Vapor Forecast
-## Integrated Water Vapor Forecast
-![]({{< meta plots.internal.iwv_itcz_edges.003h >}})
 
 ## Integrated Water Vapor Forecast
 ![]({{< meta plots.internal.iwv_itcz_edges.012h >}})
@@ -48,8 +44,6 @@ title: "PERCUSION Weather briefing"
 
 
 # ECMWF Outgoing Longwave Radiation
-## Outgoing Longwave Radiation Forecast
-![]({{< meta plots.internal.toa_outgoing_longwave.003h >}})
 
 ## Outgoing Longwave Radiation Forecast
 ![]({{< meta plots.internal.toa_outgoing_longwave.012h >}})
@@ -67,8 +61,6 @@ title: "PERCUSION Weather briefing"
 ![]({{< meta plots.internal.toa_outgoing_longwave.108h >}})
 
 # ECMWF 10m Surface Wind Speed
-## 10m surface wind speed forecast
-![]({{< meta plots.internal.sfc_winds.003h >}})
 
 ## 10m surface wind speed forecast
 ![]({{< meta plots.internal.sfc_winds.012h >}})
@@ -86,8 +78,6 @@ title: "PERCUSION Weather briefing"
 ![]({{< meta plots.internal.sfc_winds.108h >}})
 
 # ECMWF Precipitation forecast
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.003h >}})
 
 ## Precipitation Forecast
 ![]({{< meta plots.internal.precip.012h >}})


### PR DESCRIPTION
- this resolves #58 (removing 3h lead forecast)
- the visible satellite image is also removed from the workflow as it is usually dark at the time the briefing is generated
- updates to the quarto template so 3h + visible satellite image don't get added to main.qmd

I also tested that the workflow to generate briefing works with these updates and it does not affect older briefings that are already generated. 
