### PR TITLE
Updates to the quarto template that groups plots together

### DIFF
--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -26,53 +26,61 @@ title: "PERCUSION Weather briefing"
 
 # ECMWF Forecasts
 
-## Lead time = 12h
+## 
+### Lead time = 12h
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.012h >}})
-![]({{< meta plots.internal.toa_outgoing_longwave.012h >}})
-![]({{< meta plots.internal.precip.012h >}})
-![]({{< meta plots.internal.sfc_winds.012h >}})
+![]({{< meta plots.internal.iwv_itcz_edges.012h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.012h >}}){width=42%}
+![]({{< meta plots.internal.toa_outgoing_longwave.012h >}}){width=42%}
+![]({{< meta plots.internal.precip.012h >}}){width=42%}
 :::
 
-## Lead time = 36h
+## 
+### Lead time = 36h
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.036h >}})
-![]({{< meta plots.internal.toa_outgoing_longwave.036h >}})
-![]({{< meta plots.internal.precip.036h >}})
-![]({{< meta plots.internal.sfc_winds.036h >}})
+![]({{< meta plots.internal.iwv_itcz_edges.036h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.036h >}}){width=42%}
+![]({{< meta plots.internal.toa_outgoing_longwave.036h >}}){width=42%}
+![]({{< meta plots.internal.precip.036h >}}){width=42%}
 :::
 
-## Lead time = 60h
+## 
+### Lead time = 60h
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.060h >}})
-![]({{< meta plots.internal.toa_outgoing_longwave.060h >}})
-![]({{< meta plots.internal.precip.060h >}})
-![]({{< meta plots.internal.sfc_winds.060h >}})
+![]({{< meta plots.internal.iwv_itcz_edges.060h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.060h >}}){width=42%}
+![]({{< meta plots.internal.toa_outgoing_longwave.060h >}}){width=42%}
+![]({{< meta plots.internal.precip.060h >}}){width=42%}
 :::
 
-## Lead time = 84h
+## 
+### Lead time = 60h
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.084h >}})
-![]({{< meta plots.internal.toa_outgoing_longwave.084h >}})
-![]({{< meta plots.internal.precip.084h >}})
-![]({{< meta plots.internal.sfc_winds.084h >}})
+![]({{< meta plots.internal.iwv_itcz_edges.084h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.084h >}}){width=42%}
+![]({{< meta plots.internal.toa_outgoing_longwave.084h >}}){width=42%}
+![]({{< meta plots.internal.precip.084h >}}){width=42%}
 :::
 
-## Lead time = 108h
+## 
+### Lead time = 108h
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.108h >}})
-![]({{< meta plots.internal.toa_outgoing_longwave.108h >}})
-![]({{< meta plots.internal.precip.108h >}})
-![]({{< meta plots.internal.sfc_winds.108h >}})
+![]({{< meta plots.internal.iwv_itcz_edges.108h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.108h >}}){width=42%}
+![]({{< meta plots.internal.toa_outgoing_longwave.108h >}}){width=42%}
+![]({{< meta plots.internal.precip.108h >}}){width=42%}
 :::
 
 # Saharan dust forecast
-
+##
 ::: {layout-nrow=2}
-![lead time = 12h]({{< meta plots.external_lead.dust.012h >}})
-![lead time = 36h]({{< meta plots.external_lead.dust.036h  >}})
-![lead time = 60h]({{< meta plots.external_lead.dust.060h  >}})
-![lead time = 84h]({{< meta plots.external_lead.dust.084h  >}})
+![lead time = 12h]({{< meta plots.external_lead.dust.012h >}}){width=75%}
+
+![lead time = 36h]({{< meta plots.external_lead.dust.036h >}}){width=75%}
+
+![lead time = 60h]({{< meta plots.external_lead.dust.060h >}}){width=75%}
+
+![lead time = 84h]({{< meta plots.external_lead.dust.084h >}}){width=75%}
 :::
 
 ##

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -54,7 +54,7 @@ title: "PERCUSION Weather briefing"
 :::
 
 ## 
-### Lead time = 60h
+### Lead time = 84h
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.084h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.084h >}}){width=42%}

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -24,93 +24,56 @@ title: "PERCUSION Weather briefing"
 ## GOES WEST Latest Infrared Image
 ![]({{< meta plots.external_inst.current_satellite_image_ir >}})
 
-# ECMWF Integrated Water Vapor Forecast
+# ECMWF Forecasts
 
-## Integrated Water Vapor Forecast
+## Lead time = 12h
+::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.012h >}})
-
-## Integrated Water Vapor Forecast
-![]({{< meta plots.internal.iwv_itcz_edges.036h >}})
-
-## Integrated Water Vapor Forecast
-![]({{< meta plots.internal.iwv_itcz_edges.060h >}})
-
-## Integrated Water Vapor Forecast
-![]({{< meta plots.internal.iwv_itcz_edges.084h >}})
-
-## Integrated Water Vapor Forecast
-![]({{< meta plots.internal.iwv_itcz_edges.108h >}})
-
-
-# ECMWF Outgoing Longwave Radiation
-
-## Outgoing Longwave Radiation Forecast
 ![]({{< meta plots.internal.toa_outgoing_longwave.012h >}})
-
-## Outgoing Longwave Radiation Forecast
-![]({{< meta plots.internal.toa_outgoing_longwave.036h >}})
-
-## Outgoing Longwave Radiation Forecast
-![]({{< meta plots.internal.toa_outgoing_longwave.060h >}})
-
-## Outgoing Longwave Radiation Forecast
-![]({{< meta plots.internal.toa_outgoing_longwave.084h >}})
-
-## Outgoing Longwave Radiation Forecast
-![]({{< meta plots.internal.toa_outgoing_longwave.108h >}})
-
-# ECMWF Precipitation forecast
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.003h >}})
-
-## Precipitation Forecast
 ![]({{< meta plots.internal.precip.012h >}})
-
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.036h >}})
-
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.060h >}})
-
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.084h >}})
-
-## Precipitation Forecast
-![]({{< meta plots.internal.precip.108h >}})
-
-# ECMWF 10m Surface Wind Speed
-
-## 10m surface wind speed forecast
 ![]({{< meta plots.internal.sfc_winds.012h >}})
+:::
 
-## 10m surface wind speed forecast
+## Lead time = 36h
+::: {layout-nrow=2}
+![]({{< meta plots.internal.iwv_itcz_edges.036h >}})
+![]({{< meta plots.internal.toa_outgoing_longwave.036h >}})
+![]({{< meta plots.internal.precip.036h >}})
 ![]({{< meta plots.internal.sfc_winds.036h >}})
+:::
 
-## 10m surface wind speed forecast
+## Lead time = 60h
+::: {layout-nrow=2}
+![]({{< meta plots.internal.iwv_itcz_edges.060h >}})
+![]({{< meta plots.internal.toa_outgoing_longwave.060h >}})
+![]({{< meta plots.internal.precip.060h >}})
 ![]({{< meta plots.internal.sfc_winds.060h >}})
+:::
 
-## 10m surface wind speed forecast
+## Lead time = 84h
+::: {layout-nrow=2}
+![]({{< meta plots.internal.iwv_itcz_edges.084h >}})
+![]({{< meta plots.internal.toa_outgoing_longwave.084h >}})
+![]({{< meta plots.internal.precip.084h >}})
 ![]({{< meta plots.internal.sfc_winds.084h >}})
+:::
 
-## 10m surface wind speed forecast
+## Lead time = 108h
+::: {layout-nrow=2}
+![]({{< meta plots.internal.iwv_itcz_edges.108h >}})
+![]({{< meta plots.internal.toa_outgoing_longwave.108h >}})
+![]({{< meta plots.internal.precip.108h >}})
 ![]({{< meta plots.internal.sfc_winds.108h >}})
+:::
 
-# ECMWF Dust
+# Saharan dust forecast
 
-## Saharan dust forecast
-![]({{< meta plots.external_lead.dust.012h >}})
-
-## Saharan dust forecast
-![]({{< meta plots.external_lead.dust.036h >}})
-
-## Saharan dust forecast
-![]({{< meta plots.external_lead.dust.060h >}})
-
-## Saharan dust forecast
-![]({{< meta plots.external_lead.dust.084h >}})
-
-## Saharan dust forecast
-![]({{< meta plots.external_lead.dust.108h >}})
+::: {layout-nrow=2}
+![lead time = 12h]({{< meta plots.external_lead.dust.012h >}})
+![lead time = 36h]({{< meta plots.external_lead.dust.036h  >}})
+![lead time = 60h]({{< meta plots.external_lead.dust.060h  >}})
+![lead time = 84h]({{< meta plots.external_lead.dust.084h  >}})
+:::
 
 ##
 :::: {.columns}


### PR DESCRIPTION
this update (resolves #60) reduces the total number of slides in the weather briefing by:
- grouping together icwv, pr, olr and sfc_wind based on forecast lead time
- all saharan dust forecasts together in a single slide