### PR TITLE
Introducing formally correct figure labels

### DIFF
--- a/src/wblib/figures/briefing_info.py
+++ b/src/wblib/figures/briefing_info.py
@@ -33,8 +33,8 @@ def format_internal_figure_axes(
     ax.coastlines(lw=1.0, color="k")
     ax.set_xticks(np.round(np.linspace(-70, 10, 9), 0), crs=crs)
     ax.set_yticks(np.round(np.linspace(-20, 20, 5), 0), crs=crs)
-    ax.set_ylabel("Latitude - \N{DEGREE SIGN}N")
-    ax.set_xlabel("Longitude - \N{DEGREE SIGN}E")
+    ax.set_ylabel("Latitude / \N{DEGREE SIGN}N")
+    ax.set_xlabel("Longitude / \N{DEGREE SIGN}E")
     ax.set_xlim([lon_min, lon_max])
     ax.set_ylim([lat_min, lat_max])
     annotation = (f"Latest ECMWF IFS forecast initialization: " +

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -56,7 +56,7 @@ def iwv_itcz_edges(
                                 sattracks_fc_time, ax)
     _draw_icwv_contours_for_previous_forecasts(forecasts, ax)
     im = _draw_icwv_current_forecast(forecast, ax)
-    fig.colorbar(im, label="IWV - kg m$^{-2}$", shrink=0.8)
+    fig.colorbar(im, label="IWV \ kg m$^{-2}$", shrink=0.8)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
     plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -77,7 +77,7 @@ def _draw_olr(olr, fig, ax) -> None:
     )
     # format colorbar
     fig.colorbar(im,
-                 label="OLR $W/m^2$",
+                 label="OLR \ W/m$^2$",
                  ticks=np.linspace(OLR_MIN, OLR_MAX, 11),
                  shrink=0.8)
 

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -131,7 +131,7 @@ def _draw_current_forecast(precip, fig, ax):
         norm=BoundaryNorm(TP_STEPS, ncolors=TP_COLORMAP.N, clip=True),
         cmap=TP_COLORMAP,
     )
-    fig.colorbar(im, label="mean precip. rate - mm day$^{-1}$", shrink=0.8)
+    fig.colorbar(im, label="mean precip. rate \ mm day$^{-1}$", shrink=0.8)
 
 
 def _add_legend(init_times: list, **kwargs):

--- a/src/wblib/figures/internal/sfc_winds.py
+++ b/src/wblib/figures/internal/sfc_winds.py
@@ -81,7 +81,7 @@ def _windspeed_plot(windspeed_10m, fig, ax):
         vmax=SPEED_MAX,
         ax=ax,
     )
-    fig.colorbar(im, label="10m wind speed - m s$^{-1}$", shrink=0.8)
+    fig.colorbar(im, label="10m wind speed \ m s$^{-1}$", shrink=0.8)
 
 
 def _wind_direction_plot(u10m, v10m, ax):


### PR DESCRIPTION
The axis labels have been given as `<label> - <unit>`. This is changed to the formally correct style `<label> / <unit>`.