### PR TITLE
Bugfix

### DIFF
--- a/src/wblib/flights/flighttrack.py
+++ b/src/wblib/flights/flighttrack.py
@@ -23,7 +23,7 @@ def plot_python_flighttrack(
         **kwargs
         ):
     valid_time = get_valid_time(briefing_time, lead_hours)
-    if flight['time'] == valid_time:
+    if flight['time'].date() == valid_time.date():
         plot_path(flight["track"], ax, **kwargs)
 
 


### PR DESCRIPTION
So far, the flight track was only plotted if the flight.time agreed to the exact valid time, which usually was the case for 12UTC. This bugfix achieves that the flighttack is plotted for all valid times of a flight day.