### PR TITLE
increasing the size of Hovmoeller plots in quarto template

### DIFF
--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -9,13 +9,13 @@ title: "PERCUSION Weather briefing"
 ## NHC tropical weather outlook
 ![]({{< meta plots.external_inst.nhc_seven_days_outlook >}})
 
-##
+## 
 :::: {.columns}
-::: {.column width="30%"}
-### NHC tropical Hovmöller
+::: {.column width="7%"}
+NHC tropical Hovmöller
 :::
-::: {.column width="70%"}
-![]({{< meta plots.external_inst.nhc_hovmoller >}}){width="61%"}
+::: {.column width="93%"}
+![]({{< meta plots.external_inst.nhc_hovmoller >}}){width="60%"}
 :::
 ::::
 


### PR DESCRIPTION
Resolves #80 
- the size of the first column in the slide is reduced, and the second column size is increased
- could need further adjusting if the lower panel of the plot is not properly displayed by the beamer. 