### PR TITLE
Slide titles with valid times

### DIFF
--- a/src/wblib/services/get_expected_figures_yaml.py
+++ b/src/wblib/services/get_expected_figures_yaml.py
@@ -26,7 +26,7 @@ def get_expected_figures(
         "location": location,
         "date": date,
         "sattracks_fc_date": sattracks_fc_date,
-        "valid_dates": get_valid_dates(date, PLOTS_LEADTIMES),
+        "valid_dates": _get_valid_dates(date, PLOTS_LEADTIMES),
         "plots": {
             "external_inst": get_expected_external_inst_figures(output_path),
             "external_lead": get_expected_external_lead_figures(output_path,
@@ -39,7 +39,7 @@ def get_expected_figures(
     }
     return variables_nml
 
-def get_valid_dates(date, lead_times) -> dict:
+def _get_valid_dates(date, lead_times) -> dict:
     valid_dates = dict()
     for lead in PLOTS_LEADTIMES:
         temp_time = (pd.Timestamp(date, tz='UTC') 

--- a/src/wblib/services/get_expected_figures_yaml.py
+++ b/src/wblib/services/get_expected_figures_yaml.py
@@ -1,14 +1,13 @@
 """Get the figures expected by the Quarto report."""
 
 from datetime import datetime
-
+import pandas as pd
 from wblib.services.get_paths import get_figure_path
 
 from wblib.services._define_figures import EXTERNAL_INST_PLOTS
 from wblib.services._define_figures import EXTERNAL_LEAD_PLOTS
 from wblib.services._define_figures import INTERNAL_PLOTS
 from wblib.services._define_figures import PLOTS_LEADTIMES
-
 
 MSS_PLOTS_SIDE_VIEW = ["relative_humidity", "cloud_cover"]
 ALLOWED_LOCATIONS = ["Barbados", "Sal"]
@@ -27,6 +26,7 @@ def get_expected_figures(
         "location": location,
         "date": date,
         "sattracks_fc_date": sattracks_fc_date,
+        "valid_dates": get_valid_dates(date, PLOTS_LEADTIMES),
         "plots": {
             "external_inst": get_expected_external_inst_figures(output_path),
             "external_lead": get_expected_external_lead_figures(output_path,
@@ -39,6 +39,13 @@ def get_expected_figures(
     }
     return variables_nml
 
+def get_valid_dates(date, lead_times) -> dict:
+    valid_dates = dict()
+    for lead in PLOTS_LEADTIMES:
+        temp_time = (pd.Timestamp(date, tz='UTC') 
+                     + pd.Timedelta(hours=int(lead[:-1]))).strftime('%Y-%m-%d %H:%M') 
+        valid_dates[lead] = str(temp_time) + ' UTC'
+    return valid_dates
 
 def get_expected_external_inst_figures(figures_output_path) -> dict:
     figures = {

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -33,7 +33,7 @@ NHC tropical Hovmöller
 # ECMWF Forecasts
 
 ## 
-### {{< meta valid_dates.012h >>}}
+### {{< meta valid_dates.012h >}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.012h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.012h >}}){width=42%}
@@ -42,7 +42,7 @@ NHC tropical Hovmöller
 :::
 
 ## 
-### Lead time = 36h
+### {{< meta valid_dates.036h >}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.036h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.036h >}}){width=42%}
@@ -51,7 +51,7 @@ NHC tropical Hovmöller
 :::
 
 ## 
-### Lead time = 60h
+### {{< meta valid_dates.060h >}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.060h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.060h >}}){width=42%}
@@ -60,7 +60,7 @@ NHC tropical Hovmöller
 :::
 
 ## 
-### Lead time = 84h
+### {{< meta valid_dates.084h >}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.084h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.084h >}}){width=42%}
@@ -69,7 +69,7 @@ NHC tropical Hovmöller
 :::
 
 ## 
-### Lead time = 108h
+### {{< meta valid_dates.108h >}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.108h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.108h >}}){width=42%}
@@ -80,13 +80,13 @@ NHC tropical Hovmöller
 # Saharan dust forecast
 ##
 ::: {layout-nrow=2}
-![lead time = 12h]({{< meta plots.external_lead.dust.012h >}}){width=75%}
+![{{< meta valid_dates.012h >}}]({{< meta plots.external_lead.dust.012h >}}){width=75%}
 
-![lead time = 36h]({{< meta plots.external_lead.dust.036h >}}){width=75%}
+![{{< meta valid_dates.036h >}}]({{< meta plots.external_lead.dust.036h >}}){width=75%}
 
-![lead time = 60h]({{< meta plots.external_lead.dust.060h >}}){width=75%}
+![{{< meta valid_dates.060h >}}]({{< meta plots.external_lead.dust.060h >}}){width=75%}
 
-![lead time = 84h]({{< meta plots.external_lead.dust.084h >}}){width=75%}
+![{{< meta valid_dates.084h >}}]({{< meta plots.external_lead.dust.084h >}}){width=75%}
 :::
 
 ##

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -33,7 +33,7 @@ NHC tropical Hovmöller
 # ECMWF Forecasts
 
 ## 
-### Lead time = 12h
+### {{< meta valid_dates.012h >>}}
 ::: {layout-nrow=2}
 ![]({{< meta plots.internal.iwv_itcz_edges.012h >}}){width=42%}
 ![]({{< meta plots.internal.sfc_winds.012h >}}){width=42%}


### PR DESCRIPTION
This PR closed issue #77 
- the titles of the slides containing HIFS forecasts contain valid dates instead of lead times (current method)
- dust plots also use valid times as the caption