### PR TITLE
Reduce the interval of previously loaded forecasts from 1D to 12H

### DIFF
--- a/src/wblib/figures/hifs.py
+++ b/src/wblib/figures/hifs.py
@@ -125,8 +125,9 @@ def _get_dates_of_previous_briefings(
     briefing_time: pd.Timestamp,
     number: int = 5,
 ) -> list[pd.Timestamp]:
-    day = pd.Timedelta("1D")
-    dates = [(briefing_time.floor("1D") - i * day) for i in range(0, number)]
+    fc_interval = pd.Timedelta("12H")
+    dates = [(briefing_time.floor("1D") - i * fc_interval)
+             for i in range(0, number)]
     dates.reverse()
     return dates
 


### PR DESCRIPTION
So far, we only loaded the 00UTC forecasts to give an impression of forecast uncertainty. This could give an unreasonably high estimate of uncertainty. Thus, we decided to also use the 1200 UTC forecasts, which means we load the latest 5 forecasts, i.e. 2.5 days.
@sortega87 Please also note this change.

**Preview:**
New contours with forecast initialization interval of 12 hours:
![interval_12h](https://github.com/user-attachments/assets/e0186c5b-276c-489d-bc1f-d3d32e57bb6b)

Old contours with forecast initialization interval of 24 hours:
![interval_24h](https://github.com/user-attachments/assets/3647da1b-4493-4696-a542-36a7f0f741c4)
