### PR TITLE
Multiple flights

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ where [BRIEFING_DATE] has the format "YYYYMMDD". This will create a new folder a
 Create the expected variable file in the folder with
 
 ```
-./wbcli.sh variables [BRIEFING_DATE] [FLIGHT_CODE] [LOCATION] [SATTRACKS_FC_DATE]
+./wbcli.sh variables [BRIEFING_DATE] [LOCATION] [SATTRACKS_FC_DATE]
 ```
 
-where [LOCATION] must be either Sal or Barbados, the [FLIGHT_CODE] is taken from the [https://orcestra-campaign.org/operation/halo.html](PERCUSION) operations page, e.g. [HALO-20240818a] and [SATTRACKS_FC_DATE] must also have the format "YYYYMMDD", where the most recent satellite forecast data can be retrieved [https://sattracks.orcestra-campaign.org](here). 
+where [LOCATION] must be either Sal or Barbados, and [SATTRACKS_FC_DATE] must also have the format "YYYYMMDD", where the most recent satellite forecast data can be retrieved [https://sattracks.orcestra-campaign.org](here).
 This will create a 'yaml' file in the briefing folder and link the '_variables.yml' file to it.
 
 Create the figures of the report with
@@ -41,16 +41,7 @@ Create the figures of the report with
 
 this will generate the report figures and save them to the corresponding briefing folder.
 
-## 2 - Add manually the MSS figures to the briefing folder.
-Add MSS figures to briefings/[BRIEFING_DATE]/mss folder.
-
-The name of the figures can be seen in briefings/[BRIEFING_DATE]/_metadata.yml
-
-```{note}
-It has established itself that MSS figures are not used in the weather briefings, so this step is redundant.
-```
-
-## 3 - Check all figures are present in the briefing folder.
+## 2 - Check all figures are present in the briefing folder.
 
 Check the status of the briefing by running
 
@@ -59,10 +50,6 @@ Check the status of the briefing by running
 ```
 
 this will check that all figures are complete and indicate possible missing ones, including those that need to be added manually to the briefing folder.
-
-```{note}
-Since at least the MSS figures are missing, this will throw an error message.
-```
 
 ## 4 - Add a summary of the weather briefing.
 Add a summary of the weather briefing in the quarto file briefings/[BRIEFING_DATE]/main.qmd.

--- a/src/wblib/api/api.py
+++ b/src/wblib/api/api.py
@@ -10,7 +10,6 @@ from wblib.api.figures import make_briefing_figures
 
 ARGUMENT_DESCRIPTIONS = {
     "date": "Issue date of the weather briefing [YYYMMDD]",
-    "flight_id": "ID of the flight",
     "sattracks_fc_date": "Issue date on the satellite track forecast [YYYMMDD]",
     "location": "Either 'Barbados' or 'Sal'",
 }
@@ -37,7 +36,7 @@ def _run_chosen_subcommand(parser):
             args.func(args.date)
         else:
             args.func(
-                args.date, args.flight_id, args.location, args.sattracks_fc_date
+                args.date, args.location, args.sattracks_fc_date
             )
     else:
         parser.print_help()
@@ -58,9 +57,6 @@ def _define_variable_subcommand(subparsers):
     )
     variable_file_parser.add_argument(
         "date", help=ARGUMENT_DESCRIPTIONS["date"]
-    )
-    variable_file_parser.add_argument(
-        "flight_id", help=ARGUMENT_DESCRIPTIONS["flight_id"]
     )
     variable_file_parser.add_argument(
         "location", help=ARGUMENT_DESCRIPTIONS["location"]

--- a/src/wblib/api/figures.py
+++ b/src/wblib/api/figures.py
@@ -11,7 +11,6 @@ from wblib.services.get_figures import generate_external_inst_figures
 from wblib.services.get_figures import generate_external_lead_figures
 from wblib.services.get_figures import generate_internal_figures
 from wblib.services.get_paths import get_briefing_path
-from wblib.flights.flighttrack import get_python_flightdata
 from wblib.api._logger import logger
 
 
@@ -26,15 +25,12 @@ def make_briefing_figures(date: str, logger: Callable = logger) -> None:
     briefing_time = pd.Timestamp(date, tz=TIME_ZONE_STR)
     sattracks_fc_date = variables_dict["sattracks_fc_date"]
     sattracks_fc_time = pd.Timestamp(sattracks_fc_date, tz=TIME_ZONE_STR)
-    flight_id = variables_dict["flight_id"]
-    flight = get_python_flightdata(flight_id)
     logger(f"External instantaneous figure time set to {current_time}", "INFO")
     for product, image in generate_external_inst_figures(
         external_location,
         current_time,
         briefing_time,
         sattracks_fc_time,
-        flight,
         logger,
         ):
         fig_path = variables_dict["plots"]["external_inst"][product]
@@ -71,14 +67,11 @@ def make_briefing_figures(date: str, logger: Callable = logger) -> None:
     briefing_time = pd.Timestamp(date, tz=TIME_ZONE_STR)
     sattracks_fc_date = variables_dict["sattracks_fc_date"]
     sattracks_fc_time = pd.Timestamp(sattracks_fc_date, tz=TIME_ZONE_STR)
-    flight_id = variables_dict["flight_id"]
-    flight = get_python_flightdata(flight_id)
     logger(f"Internal figure time set to {briefing_time}", "INFO")
     for product, lead_time, image in generate_internal_figures(
         briefing_time,
         current_time,
         sattracks_fc_time,
-        flight,
         logger,
         ):
         fig_path = variables_dict["plots"]["internal"][product][lead_time]

--- a/src/wblib/api/status.py
+++ b/src/wblib/api/status.py
@@ -26,7 +26,6 @@ def check_briefing_status(date: str) -> None:
     status, reason = _check_variables_files_exists(date, status, reason)
     status, reason = _check_external_images_exists(date, status, reason)
     status, reason = _check_internal_images_exists(date, status, reason)
-    status, reason = _check_mss_images_exists(date, status, reason)
     reset = colorama.Style.RESET_ALL
     if status == Status.READY_FOR_QUARTO:
         style = colorama.Fore.GREEN
@@ -86,22 +85,6 @@ def _check_external_images_exists(date, status, reason) -> tuple[Status, str]:
             status = Status.INCOMPLETE
             reason = f"Internal plot '{plot_name}' not found."
             break
-    return status, reason
-
-
-def _check_mss_images_exists(date, status, reason) -> tuple[Status, str]:
-    if status == Status.INCOMPLETE:
-        return status, reason
-    variables_path = Path(get_variables_path(date))
-    with open(variables_path, "r") as file:
-        variables = yaml.safe_load(file)
-    for plot_root, model_dict in variables["plots"]["mss_side_view"].items():
-        for model, plot_path_str in model_dict.items():
-            plot_path = Path(plot_path_str)
-            if not plot_path.exists():
-                status = Status.INCOMPLETE
-                reason = f"MSS side view plot '{plot_root}' not found for model '{model}'"
-                break
     return status, reason
 
 

--- a/src/wblib/api/variables_file.py
+++ b/src/wblib/api/variables_file.py
@@ -12,13 +12,12 @@ from wblib.services import get_expected_figures
 
 def make_briefing_variables(
     date: str,
-    flight_id: str,
     location: str,
     sattracks_fc_date: str,
     logger: Callable = logger,
 ) -> None:
     variables_nml = get_expected_figures(
-        date, location, flight_id, sattracks_fc_date
+        date, location, sattracks_fc_date
     )
     variables_file_name = f"_metadata.yml"
     output_path = pathlib.Path(get_briefing_path(date))
@@ -33,4 +32,4 @@ def make_briefing_variables(
 if __name__ == "__main__":
     from wblib.api._logger import logger
 
-    make_briefing_variables("20240101", "FX2", "Barbados", logger)
+    make_briefing_variables("20240101", "Barbados", "20240817", logger)

--- a/src/wblib/figures/external/goes_2_go.py
+++ b/src/wblib/figures/external/goes_2_go.py
@@ -11,18 +11,18 @@ from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE, ORCESTRA_DOMAIN
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 def yesterdays_goes2go_image(
         current_time: pd.Timestamp,
         briefing_time: pd.Timestamp,
         sattracks_fc_time: pd.Timestamp,
-        flight: dict,
         *args
         ):
     yesterday = briefing_time - pd.Timedelta("12h")
     goes_data_yesterday = _get_goes2go_data(yesterday)
     figure = plot_goes2go_satimage(goes_data_yesterday, yesterday,
-                                   sattracks_fc_time, flight)
+                                   sattracks_fc_time)
     return figure
 
 
@@ -30,12 +30,11 @@ def latest_goes2go_image(
         current_time: pd.Timestamp,
         briefing_time: pd.Timestamp,
         sattracks_fc_time: pd.Timestamp,
-        flight: dict,
         *args
         ):
     goes_data_latest = _get_goes2go_data_latest()
     figure = plot_goes2go_satimage(goes_data_latest, briefing_time,
-                                   sattracks_fc_time, flight)
+                                   sattracks_fc_time)
     return figure
 
 
@@ -85,7 +84,6 @@ def plot_goes2go_satimage(
         goes_object: xr.Dataset,
         briefing_time: pd.Timestamp,
         sattracks_fc_time: pd.Timestamp,
-        flight: dict,
         goes_variable: str="TrueColor",
         ) -> Figure:
     sns.set_context("talk")
@@ -104,8 +102,10 @@ def plot_goes2go_satimage(
     plt.title(f"Valid time: {str(goes_object.t.values)[:19]} UTC", pad=15)
     plot_sattrack(ax, briefing_time, "00H", sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, "00H", ax, color="C1",
-                            show_waypoints=False)
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, "00H", ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -115,15 +115,12 @@ if __name__ == "__main__":
     sattracks_fc_time = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
     briefing_time = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
     current_time = pd.Timestamp(2024, 8, 11, 9, 30).tz_localize("UTC")
-    flight = get_python_flightdata('HALO-20240811a')
 
-    latest_goes2go_image(current_time, briefing_time, sattracks_fc_time, flight)
+    latest_goes2go_image(current_time, briefing_time, sattracks_fc_time)
 
     # test get_yesterdays_goes2go_image()
     sattracks_fc_time = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
     briefing_time = pd.Timestamp(2024, 8, 12).tz_localize("UTC")
     current_time = pd.Timestamp(2024, 8, 12, 9, 30).tz_localize("UTC")
-    flight = get_python_flightdata('HALO-20240811a')
 
-    yesterdays_goes2go_image(current_time, briefing_time, sattracks_fc_time,
-                             flight)
+    yesterdays_goes2go_image(current_time, briefing_time, sattracks_fc_time)

--- a/src/wblib/figures/internal/cld_top_height.py
+++ b/src/wblib/figures/internal/cld_top_height.py
@@ -16,6 +16,8 @@ from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 CATALOG_OLR_CODE = "ttr"
 CATALOG_ICWV_CODE = "tcwv"
@@ -34,7 +36,6 @@ def cloud_top_height(
     lead_hours: str,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     hifs: HifsForecasts,
 ) -> Figure:
     issue_time, diff_ttr = hifs.get_forecast(
@@ -71,8 +72,10 @@ def cloud_top_height(
     _draw_icwv_contour(icwv, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",
-                            show_waypoints=False)
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -131,16 +134,14 @@ def _draw_icwv_contour(icwv, ax):
 
 if __name__ == "__main__":
     import intake
-    from wblib.flights.flighttrack import get_python_flightdata
-
+    
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
     hifs = HifsForecasts(incatalog)
     briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 11, 12).tz_localize("UTC")
     sattracks_fc_time1 = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
-    test_flight = get_python_flightdata('HALO-20240813a')
     fig = cloud_top_height(
-        briefing_time1, "60H", current_time1, sattracks_fc_time1, test_flight,
-        hifs)
+        briefing_time1, "60H", current_time1, sattracks_fc_time1, hifs
+        )
     fig.savefig("test1.png")

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -16,6 +16,8 @@ from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 ICWV_ITCZ_THRESHOLD = 48  # mm
 ICWV_MAX = 70  # mm
@@ -37,7 +39,6 @@ def iwv_itcz_edges(
     lead_hours: str,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     hifs: HifsForecasts,
 ) -> Figure:
     issue_time, forecast = hifs.get_forecast(
@@ -59,9 +60,10 @@ def iwv_itcz_edges(
     fig.colorbar(im, label="IWV / kg m$^{-2}$", shrink=0.8)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",
-                            show_waypoints=False)
-    
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -94,15 +96,13 @@ def _draw_icwv_current_forecast(forecast, ax):
 
 if __name__ == "__main__":
     import intake
-    from wblib.flights.flighttrack import get_python_flightdata
-
+    
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
     hifs = HifsForecasts(incatalog)
     briefing_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 15, 12).tz_localize("UTC")
     sattracks_fc_time1 = pd.Timestamp(2024, 8, 15).tz_localize("UTC")
-    test_flight = get_python_flightdata('HALO-20240813a')
     fig = iwv_itcz_edges(briefing_time1, "60H", current_time1,
-                         sattracks_fc_time1, test_flight, hifs)
+                         sattracks_fc_time1, hifs)
     fig.savefig("test1.png")

--- a/src/wblib/figures/internal/olr.py
+++ b/src/wblib/figures/internal/olr.py
@@ -16,6 +16,8 @@ from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 CATALOG_OLR_CODE = "ttr"
 CATALOG_ICWV_CODE = "tcwv"
@@ -32,7 +34,6 @@ def toa_outgoing_longwave(
     lead_hours: str,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     hifs: HifsForecasts,
 ) -> Figure:
     issue_time, diff_ttr = hifs.get_forecast(
@@ -59,8 +60,10 @@ def toa_outgoing_longwave(
     _draw_icwv_contour(icwv, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",
-                            show_waypoints=False)
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -96,7 +99,6 @@ def _draw_icwv_contour(icwv, ax):
 
 if __name__ == "__main__":
     import intake
-    from wblib.flights.flighttrack import get_python_flightdata
 
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
@@ -104,7 +106,6 @@ if __name__ == "__main__":
     briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 11, 12).tz_localize("UTC")
     sattracks_fc_time1 = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
-    test_flight = get_python_flightdata('HALO-20240813a')
     fig = toa_outgoing_longwave(briefing_time1, "60H", current_time1,
-                                sattracks_fc_time1, test_flight, hifs)
+                                sattracks_fc_time1, hifs)
     fig.savefig("test1.png")

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -20,6 +20,8 @@ from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
 from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 TP_THRESHOLD = 50  # mm
 TCWV_THRESHOLD = 48  # mm
@@ -41,7 +43,6 @@ def precip(
     lead_hours: str,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     hifs: HifsForecasts,
 ) -> Figure:
     # retrieve the forecast data
@@ -86,8 +87,10 @@ def precip(
     _draw_current_forecast(precip, fig, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",
-                            show_waypoints=False)
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -159,10 +162,10 @@ if __name__ == "__main__":
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
     hifs = HifsForecasts(incatalog)
-    briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
-    current_time1 = pd.Timestamp(2024, 8, 11, 12).tz_localize("UTC")
-    sattracks_fc_time1 = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
-    test_flight = get_python_flightdata('HALO-20240813a')
-    fig = precip(briefing_time1, "60H", current_time1,
-                 sattracks_fc_time1, test_flight, hifs)
-    fig.savefig("test1.png")
+    briefing_time1 = pd.Timestamp(2024, 8, 19).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 19, 12).tz_localize("UTC")
+    sattracks_fc_time1 = pd.Timestamp(2024, 8, 17).tz_localize("UTC")
+    test_flight = get_python_flightdata('HALO-20240821a')
+    fig = precip(briefing_time1, "48H", current_time1,
+                 sattracks_fc_time1, hifs)
+    fig.savefig("test2.png")

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -157,7 +157,6 @@ def _add_legend(init_times: list, **kwargs):
 
 if __name__ == "__main__":
     import intake
-    from wblib.flights.flighttrack import get_python_flightdata
 
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)

--- a/src/wblib/figures/internal/sfc_winds.py
+++ b/src/wblib/figures/internal/sfc_winds.py
@@ -18,6 +18,8 @@ from wblib.figures.briefing_info import format_internal_figure_axes
 from wblib.figures.hifs import HifsForecasts
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
 
 
 FORECAST_PUBLISH_LAG = "6h"
@@ -34,7 +36,6 @@ def sfc_winds(
     lead_hours: str,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     hifs: HifsForecasts,
 ) -> Figure:
     issue_time, u10m = hifs.get_forecast(
@@ -56,8 +57,10 @@ def sfc_winds(
     _windspeed_contour(windspeed_10m, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
-    plot_python_flighttrack(flight, briefing_time, lead_hours, ax, color="C1",
-                            show_waypoints=False)
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -122,7 +125,6 @@ def _wind_direction_plot(u10m, v10m, ax):
 
 if __name__ == "__main__":
     import intake
-    from wblib.flights.flighttrack import get_python_flightdata
 
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
@@ -130,7 +132,6 @@ if __name__ == "__main__":
     briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 11, 12).tz_localize("UTC")
     sattracks_fc_time1 = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
-    test_flight = get_python_flightdata('HALO-20240813a')
     fig = sfc_winds(briefing_time1, "60H", current_time1,
-                    sattracks_fc_time1, test_flight, hifs)
+                    sattracks_fc_time1, hifs)
     fig.savefig("test1.png")

--- a/src/wblib/services/get_expected_figures_yaml.py
+++ b/src/wblib/services/get_expected_figures_yaml.py
@@ -14,7 +14,7 @@ ALLOWED_LOCATIONS = ["Barbados", "Sal"]
 
 
 def get_expected_figures(
-    date: str, location: str, flight_id: str, sattracks_fc_date: str
+    date: str, location: str, sattracks_fc_date: str
 ) -> dict:
     """Returns a dictionary with the expected figures for the briefing."""
     _validate_date(date)
@@ -22,7 +22,6 @@ def get_expected_figures(
     _validate_location(location)
     output_path = get_figure_path()
     variables_nml = {
-        "flight_id": flight_id,
         "location": location,
         "date": date,
         "sattracks_fc_date": sattracks_fc_date,
@@ -32,9 +31,6 @@ def get_expected_figures(
             "external_lead": get_expected_external_lead_figures(output_path,
                                                                 date),
             "internal": get_expected_internal_figures(output_path, date),
-            "mss_side_view": get_expected_mss_side_view_figures(
-                output_path, date, flight_id
-            ),
         },
     }
     return variables_nml
@@ -76,22 +72,6 @@ def get_expected_internal_figures(figures_output_path, date) -> dict:
                 lead_time
             ] = (f"{figures_output_path}/internal/IFS_{date}+{lead_time}_" +
                  f"{product}.png")
-    return figures
-
-
-def get_expected_mss_side_view_figures(
-    figures_output_path, date, flight_id
-) -> dict:
-    figures = {
-        "IFS": {
-            product: f"{figures_output_path}/mss/MSS_{flight_id}_sideview_IFS_{date}_{product}.png"
-            for product in MSS_PLOTS_SIDE_VIEW
-        },
-        "ICON": {
-            product: f"{figures_output_path}/mss/MSS_{flight_id}_sideview_ICON_{date}_{product}.png"
-            for product in MSS_PLOTS_SIDE_VIEW
-        },
-    }
     return figures
 
 

--- a/src/wblib/services/get_figures.py
+++ b/src/wblib/services/get_figures.py
@@ -22,7 +22,6 @@ def generate_external_inst_figures(
     current_time: pd.Timestamp,
     briefing_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     logger: Callable
 ) -> Iterator[tuple[str, Image]]:
     for product, function in EXTERNAL_INST_PLOTS.items():
@@ -31,7 +30,7 @@ def generate_external_inst_figures(
             continue
         try:
             figure = function(current_time, briefing_time, sattracks_fc_time,
-                              flight, current_location)
+                              current_location)
             yield (product, figure)
         except Exception as error:
             msg = (
@@ -77,7 +76,6 @@ def generate_internal_figures(
     briefing_time: pd.Timestamp,
     current_time: pd.Timestamp,
     sattracks_fc_time: pd.Timestamp,
-    flight: dict,
     logger: Callable
 ) -> Iterator[tuple[str, str, Image]]:
     catalog = intake.open_catalog(INTAKE_CATALOG_URL)
@@ -93,7 +91,6 @@ def generate_internal_figures(
                     lead_hours,
                     current_time,
                     sattracks_fc_time,
-                    flight,
                     hifs
                 )
                 figure.tight_layout(pad=1.01)
@@ -114,13 +111,11 @@ def _warn_function_is_not_defined(product, logger):
     logger(msg, "ERROR")
 
 if __name__ == "__main__":
-    from wblib.flights.flighttrack import get_python_flightdata
     def logger(message: str, level: str) -> None:
         return None
     sattracks_fc_time = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
     briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
     current_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
-    flight = get_python_flightdata('HALO-20240811a')
-    figures = generate_goes2go_figures(
-        briefing_time1, sattracks_fc_time, flight, logger)
+    figures = generate_internal_figures(
+        briefing_time1, current_time1, sattracks_fc_time, logger)
     next(figures)

--- a/src/wblib/services/get_paths.py
+++ b/src/wblib/services/get_paths.py
@@ -26,7 +26,6 @@ def get_briefing_paths(date: str) -> list[str]:
         f"{figures_output_path}/internal",
         f"{figures_output_path}/external_inst",
         f"{figures_output_path}/external_lead",
-        f"{figures_output_path}/mss",
     ]
     return briefing_paths
 


### PR DESCRIPTION
This MR...

1. ...plots the flighttrack on each flight day by default. This also means that providing the flight ID in `./wbcli.sh variables` becomes useless.
2. ...therefore modifies the interface so that no flight ID must be provided to `./wbcli.sh variables` anymore. The README is adapted accordingly.
3. ...removes all the capabilities to include MSS plots. This is a consequence of no longer providing the flight ID to `./wbcli.sh variables`, but this shouldn't be a problem since we didn't use MSS plots in any briefing so far.