### PR TITLE
Add current Meteor position to some plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Creating a new weather briefing presentations consists of the following steps:
 4. Preview the weather briefing presentation.
 5. Upload the weather briefing folder to the git repository.
 
+IMPORTANT: If you want to include the latest Meteor position, you have to generate a file `~/.config/orcestra/planet.json`, which includes your PLANET ground credentials as:
+
+```
+{
+    "user": "<username>",
+    "password": "<password>"
+}
+```
+
 ## 1 - Start a new weather briefing, generate its automatic figures, and its quarto files.
 
 Use **wbcli.sh** for this. Initialize a new folder with

--- a/src/wblib/figures/external/goes.py
+++ b/src/wblib/figures/external/goes.py
@@ -16,6 +16,8 @@ from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
 
+from wblib.figures.meteor_pos import plot_meteor_latest_position
+
 API_DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 TIME_ROUND_FREQUENCY = "10min"
 TIME_LAG = "1h"
@@ -110,6 +112,7 @@ def _get_figure(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, "00", ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_latest_position(ax, color="blue", marker="*", zorder=10)
     _format_axes(plot_type, query_time_str, ax)
     return fig
 

--- a/src/wblib/figures/external/goes_2_go.py
+++ b/src/wblib/figures/external/goes_2_go.py
@@ -13,6 +13,8 @@ from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
 
+from wblib.figures.meteor_pos import plot_meteor_position
+
 def yesterdays_goes2go_image(
         current_time: pd.Timestamp,
         briefing_time: pd.Timestamp,
@@ -22,7 +24,7 @@ def yesterdays_goes2go_image(
     yesterday = briefing_time - pd.Timedelta("12h")
     goes_data_yesterday = _get_goes2go_data(yesterday)
     figure = plot_goes2go_satimage(goes_data_yesterday, yesterday,
-                                   sattracks_fc_time)
+                                   sattracks_fc_time, yesterday)
     return figure
 
 
@@ -34,7 +36,7 @@ def latest_goes2go_image(
         ):
     goes_data_latest = _get_goes2go_data_latest()
     figure = plot_goes2go_satimage(goes_data_latest, briefing_time,
-                                   sattracks_fc_time)
+                                   sattracks_fc_time, current_time)
     return figure
 
 
@@ -84,6 +86,7 @@ def plot_goes2go_satimage(
         goes_object: xr.Dataset,
         briefing_time: pd.Timestamp,
         sattracks_fc_time: pd.Timestamp,
+        meteor_time: pd.Timestamp,
         goes_variable: str="TrueColor",
         ) -> Figure:
     sns.set_context("talk")
@@ -106,6 +109,7 @@ def plot_goes2go_satimage(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, "00H", ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_position(meteor_time, ax, color="red", marker="*", zorder=10)
     matplotlib.rc_file_defaults()
     return fig
 

--- a/src/wblib/figures/internal/cld_top_height.py
+++ b/src/wblib/figures/internal/cld_top_height.py
@@ -18,6 +18,7 @@ from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
+from wblib.figures.meteor_pos import plot_meteor_latest_position_in_ifs_forecast
 
 CATALOG_OLR_CODE = "ttr"
 CATALOG_ICWV_CODE = "tcwv"
@@ -76,6 +77,8 @@ def cloud_top_height(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time, lead_hours, ax, color="k", marker="*", zorder=10)
     matplotlib.rc_file_defaults()
     return fig
 
@@ -138,10 +141,10 @@ if __name__ == "__main__":
     CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
     incatalog = intake.open_catalog(CATALOG_URL)
     hifs = HifsForecasts(incatalog)
-    briefing_time1 = pd.Timestamp(2024, 8, 11).tz_localize("UTC")
-    current_time1 = pd.Timestamp(2024, 8, 11, 12).tz_localize("UTC")
-    sattracks_fc_time1 = pd.Timestamp(2024, 8, 5).tz_localize("UTC")
+    briefing_time1 = pd.Timestamp(2024, 8, 21).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 21, 12).tz_localize("UTC")
+    sattracks_fc_time1 = pd.Timestamp(2024, 8, 21).tz_localize("UTC")
     fig = cloud_top_height(
-        briefing_time1, "60H", current_time1, sattracks_fc_time1, hifs
+        briefing_time1, "12H", current_time1, sattracks_fc_time1, hifs
         )
     fig.savefig("test1.png")

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -18,6 +18,7 @@ from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
+from wblib.figures.meteor_pos import plot_meteor_latest_position_in_ifs_forecast
 
 ICWV_ITCZ_THRESHOLD = 48  # mm
 ICWV_MAX = 70  # mm
@@ -65,6 +66,8 @@ def iwv_itcz_edges(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time, lead_hours, ax, color="k", marker="*", zorder=10)
     matplotlib.rc_file_defaults()
     return fig
 

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -22,6 +22,7 @@ from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
+from wblib.figures.meteor_pos import plot_meteor_latest_position_in_ifs_forecast
 
 TP_THRESHOLD = 50  # mm
 TCWV_THRESHOLD = 48  # mm
@@ -30,8 +31,6 @@ TP_COLORMAP = cmo.cm.rain
 DATA_CATALOG_VARIABLE = ["tp", "tcwv"]
 REFDATE_COLORBAR_TP = [
     "red"
-    #"#ff7e26",
-    #"#ff580f",
 ]  # the ordering of the colors indicate the latest available refdate
 REFDATE_COLORBAR_TCWV = [
     "dodgerblue",
@@ -93,6 +92,8 @@ def precip(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time, lead_hours, ax, color="k", marker="*", zorder=10)
     matplotlib.rc_file_defaults()
     return fig
 

--- a/src/wblib/figures/internal/sfc_winds.py
+++ b/src/wblib/figures/internal/sfc_winds.py
@@ -20,7 +20,7 @@ from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
 from wblib.flights._define_flights import FLIGHTS
-
+from wblib.figures.meteor_pos import plot_meteor_latest_position_in_ifs_forecast
 
 FORECAST_PUBLISH_LAG = "6h"
 SPEED_THRESHOLD = 3  # m/s
@@ -61,6 +61,8 @@ def sfc_winds(
         flight = get_python_flightdata(flight_id)
         plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
                                 color="C1", show_waypoints=False)
+    plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time, lead_hours, ax, color="k", marker="*", zorder=10)
     matplotlib.rc_file_defaults()
     return fig
 

--- a/src/wblib/figures/meteor_pos.py
+++ b/src/wblib/figures/meteor_pos.py
@@ -1,10 +1,16 @@
+import pandas as pd
 from orcestra.meteor import get_meteor_track
-
 
 def plot_meteor_latest_position(ax, **kwargs):
     meteor = get_meteor_track(deduplicate_latlon=True)
     meteor_latest = meteor.isel(time=-1)
     ax.scatter(meteor_latest["lon"], meteor_latest["lat"], **kwargs)
+
+
+def plot_meteor_position(time: pd.Timestamp, ax, **kwargs):
+    meteor = get_meteor_track(deduplicate_latlon=True)
+    meteor_pos = meteor.sel(time=time, method="nearest")
+    ax.scatter(meteor_pos["lon"], meteor_pos["lat"], **kwargs)
 
 
 def plot_meteor_track(ax, **kwargs):

--- a/src/wblib/figures/meteor_pos.py
+++ b/src/wblib/figures/meteor_pos.py
@@ -1,5 +1,16 @@
 import pandas as pd
 from orcestra.meteor import get_meteor_track
+from wblib.figures.hifs import get_valid_time
+
+
+def plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time: pd.Timestamp, lead_hours: str, ax, **kwargs):
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    if briefing_time.date() == valid_time.date():
+        meteor = get_meteor_track(deduplicate_latlon=True)
+        meteor_latest = meteor.isel(time=-1)
+        ax.scatter(meteor_latest["lon"], meteor_latest["lat"], **kwargs)
+
 
 def plot_meteor_latest_position(ax, **kwargs):
     meteor = get_meteor_track(deduplicate_latlon=True)

--- a/src/wblib/figures/meteor_pos.py
+++ b/src/wblib/figures/meteor_pos.py
@@ -1,0 +1,12 @@
+from orcestra.meteor import get_meteor_track
+
+
+def plot_meteor_latest_position(ax, **kwargs):
+    meteor = get_meteor_track(deduplicate_latlon=True)
+    meteor_latest = meteor.isel(time=-1)
+    ax.scatter(meteor_latest["lon"], meteor_latest["lat"], **kwargs)
+
+
+def plot_meteor_track(ax, **kwargs):
+    meteor = get_meteor_track(deduplicate_latlon=True)
+    ax.plot(meteor["lon"], meteor["lat"], **kwargs)


### PR DESCRIPTION
With this MR, the current Meteor position is plotted into the latest satellite images and the IFS forecast maps of the briefing day (lead time +12h). Including it into IFS forecasts maps with lead times >12h doesn't make sense, as Meteor will move and won't be on the current position anymore on the valid day. Track forecasts for Meteor don't exist.

Furthermore, the position of Meteor at the time of yesterday's satellite image is included into that plot.

@sortega87 @dspraturi @karstenpeters @Lucalino Please note this pull request and the associated changes! More information also in our private Mattermost channel.