### PR TITLE
Add ensemble forecasts

### DIFF
--- a/src/wblib/figures/internal/cld_top_height.py
+++ b/src/wblib/figures/internal/cld_top_height.py
@@ -81,7 +81,7 @@ def cloud_top_height(
         subplot_kw={"projection": ccrs.PlateCarree()},
     )
     format_internal_figure_axes(briefing_time, lead_hours, issue_time,
-                                sattracks_fc_time, ax)
+                                sattracks_fc_time, "cloud_top_height", ax)
     _draw_cloud_top_height(cloud_top_height, fig, ax)
     _draw_tcwv_contours_for_previous_forecasts(tcwv_forecasts, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,

--- a/src/wblib/figures/internal/icwv.py
+++ b/src/wblib/figures/internal/icwv.py
@@ -58,7 +58,7 @@ def iwv_itcz_edges(
         subplot_kw={"projection": ccrs.PlateCarree()}
     )
     format_internal_figure_axes(briefing_time, lead_hours, issue_time,
-                                sattracks_fc_time, ax)
+                                sattracks_fc_time, "iwv_itcz_edges", ax)
     _draw_icwv_contours_for_previous_forecasts(forecasts, ax)
     im = _draw_icwv_current_forecast(forecast, ax)
     fig.colorbar(im, label="IWV / kg m$^{-2}$", shrink=0.8)

--- a/src/wblib/figures/internal/icwv_ens.py
+++ b/src/wblib/figures/internal/icwv_ens.py
@@ -1,0 +1,155 @@
+"""Plot ITCZ edges based on the IWV from ECMWF IFS."""
+
+import intake
+import easygems.healpix as egh
+import matplotlib.pyplot as plt
+import cartopy.crs as ccrs
+import numpy as np
+import pandas as pd
+import xarray as xr
+import warnings
+
+import matplotlib
+from matplotlib.figure import Figure
+import seaborn as sns
+
+from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
+from wblib.figures.briefing_info import format_internal_figure_axes
+from wblib.figures.hifs import HifsForecasts
+from wblib.figures.sattrack import plot_sattrack
+from wblib.flights.flighttrack import plot_python_flighttrack
+from wblib.flights.flighttrack import get_python_flightdata
+from wblib.flights._define_flights import FLIGHTS
+from wblib.figures.meteor_pos import plot_meteor_latest_position_in_ifs_forecast
+
+ICWV_ITCZ_THRESHOLD = 48  # mm
+ICWV_MAX = 70  # mm
+ICWV_MIN = 45  # mm
+ICWV_COLORMAP = "Blues"
+ICWV_CATALOG_VARIABLE = "tcwv"
+REFDATE_COLORBAR = [
+    "#ff0000",
+    "#bf0000",
+    "#800000",
+    "#400000",
+    "#000000"
+] # the ordering of the colors indicate the latest available refdate
+REFDATE_LINEWIDTH = [1, 1.1, 1.2, 1.3, 1.5]
+
+
+def iwv_itcz_edges_ens(
+    briefing_time: pd.Timestamp,
+    lead_hours: str,
+    current_time: pd.Timestamp,
+    sattracks_fc_time: pd.Timestamp,
+    meteor_track: xr.Dataset,
+    hifs: HifsForecasts,
+) -> Figure:
+    issue_time_oper, forecast_oper = hifs.get_forecast(
+        ICWV_CATALOG_VARIABLE, briefing_time, lead_hours, current_time,
+        forecast_type="oper"
+    )
+    issue_time_enfo, forecast_enfo = hifs.get_forecast(
+        ICWV_CATALOG_VARIABLE, briefing_time, lead_hours, current_time,
+        forecast_type="enfo"
+    )
+    _validate_issue_times(issue_time_oper, issue_time_enfo)
+    # plot
+    sns.set_context("talk")
+    fig, ax = plt.subplots(
+        figsize=INTERNAL_FIGURE_SIZE,
+        subplot_kw={"projection": ccrs.PlateCarree()}
+    )
+    format_internal_figure_axes(briefing_time, lead_hours, issue_time_oper,
+                                sattracks_fc_time, ax)
+    _draw_icwv_enfo_contours(forecast_enfo, ax)
+    _draw_icwv_enfo_mean_contour(forecast_enfo, ax)
+    _draw_icwv_oper_contour(forecast_oper, ax)
+    plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
+                  which_orbit="descending")
+    for flight_id in FLIGHTS:
+        flight = get_python_flightdata(flight_id)
+        plot_python_flighttrack(flight, briefing_time, lead_hours, ax,
+                                color="C1", show_waypoints=False)
+    plot_meteor_latest_position_in_ifs_forecast(
+        briefing_time, lead_hours, ax, meteor=meteor_track)
+    matplotlib.rc_file_defaults()
+    return fig
+
+
+def _validate_issue_times(
+        issue_time_oper: pd.Timestamp, issue_time_enfo):
+    """Give a warning if issue times of operational forecast and ensemble
+    forecast disagree."""
+    msg = (f"WARNING: Issue times of operational forecast and ensemble " +
+           f"forecast disagree! Issue time of operational forecast is " +
+           f"{issue_time_oper.strftime('%Y-%m-%dT%HUTC')}, issue time of " +
+           f"ensemble forecast is {issue_time_enfo.strftime('%Y-%m-%dT%HUTC')}!"
+           )
+    if issue_time_oper != issue_time_enfo:
+        warnings.warn(msg)
+
+
+def _draw_icwv_oper_contour(forecast, ax):
+    color = "#000000"
+    linewidth = 2.0
+    egh.healpix_contour(
+        forecast,
+        ax=ax,
+        levels=[ICWV_ITCZ_THRESHOLD],
+        colors=color,
+        linewidths=linewidth,
+    )
+
+
+def _draw_icwv_enfo_contours(forecasts, ax):
+    color = "#bf0000"
+    linewidth = 0.8
+    alpha = 0.15
+    for member in forecasts["member"]:
+        egh.healpix_contour(
+            forecasts.sel(member=member),
+            ax=ax,
+            levels=[ICWV_ITCZ_THRESHOLD],
+            colors=color,
+            linewidths=linewidth,
+            alpha=alpha,
+        )
+
+
+def _draw_icwv_enfo_mean_contour(forecasts, ax):
+    color = "#800000",
+    linewidth = 2.0,
+    enfo_mean = forecasts.mean(dim="member")
+    egh.healpix_contour(
+        enfo_mean,
+        ax=ax,
+        levels=[ICWV_ITCZ_THRESHOLD],
+        colors=color,
+        linewidths=linewidth,
+    )
+
+
+    egh.healpix_contour(
+        enfo_mean,
+        ax=ax,
+        levels=[ICWV_ITCZ_THRESHOLD],
+        colors=color,
+        linewidths=linewidth,
+    )
+
+
+if __name__ == "__main__":
+    import intake
+    from orcestra.meteor import get_meteor_track
+    
+    CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+    incatalog = intake.open_catalog(CATALOG_URL)
+    hifs = HifsForecasts(incatalog)
+    briefing_time1 = pd.Timestamp(2024, 8, 31).tz_localize("UTC")
+    current_time1 = pd.Timestamp(2024, 8, 31, 10).tz_localize("UTC")
+    sattracks_fc_time1 = pd.Timestamp(2024, 8, 31).tz_localize("UTC")
+    meteor_track = get_meteor_track(deduplicate_latlon=True)
+    fig = iwv_itcz_edges_ens(briefing_time1, "12H", current_time1,
+                         sattracks_fc_time1, meteor_track, hifs)
+    fig.savefig("test_icwv_enfo.png")

--- a/src/wblib/figures/internal/icwv_ens.py
+++ b/src/wblib/figures/internal/icwv_ens.py
@@ -141,10 +141,6 @@ def _draw_icwv_ERA5_contour(climatology, ax):
     color = "gray"
     linewidth = 2.0
     ls = '--'
-    #cat = intake.open_catalog("https://tcodata.mpimet.mpg.de/internal.yaml")
-    #hera5 = cat.HERA5.to_dask().pipe(egh.attach_coords)["tcwv"]
-    #augsep_clim = hera5.sel(
-    #    time=hera5['time'].dt.month.isin([8, 9])).mean(dim="time")
     egh.healpix_contour(
         climatology,
         ax=ax,
@@ -173,7 +169,9 @@ def _load_rolling_daily_climatology(var: str="tcwv"):
         hera5["time"] < np.datetime64("2023-01-01"), drop=True
         )
     hera5_running_mean = hera5_subsample.rolling(time=7, center=True).mean()
-    return hera5_running_mean.groupby('time.dayofyear').mean()
+    hera5_running_mean_reduced = hera5_running_mean.sel(
+        time=hera5_running_mean['time'].dt.month.isin([9]))
+    return hera5_running_mean_reduced.groupby('time.dayofyear').mean()
 
 
 if __name__ == "__main__":

--- a/src/wblib/figures/internal/icwv_ens.py
+++ b/src/wblib/figures/internal/icwv_ens.py
@@ -11,11 +11,12 @@ import warnings
 
 import matplotlib
 from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 import seaborn as sns
 
 from wblib.figures.briefing_info import INTERNAL_FIGURE_SIZE
 from wblib.figures.briefing_info import format_internal_figure_axes
-from wblib.figures.hifs import HifsForecasts
+from wblib.figures.hifs import HifsForecasts, get_valid_time
 from wblib.figures.sattrack import plot_sattrack
 from wblib.flights.flighttrack import plot_python_flighttrack
 from wblib.flights.flighttrack import get_python_flightdata
@@ -27,17 +28,8 @@ ICWV_MAX = 70  # mm
 ICWV_MIN = 45  # mm
 ICWV_COLORMAP = "Blues"
 ICWV_CATALOG_VARIABLE = "tcwv"
-REFDATE_COLORBAR = [
-    "#ff0000",
-    "#bf0000",
-    "#800000",
-    "#400000",
-    "#000000"
-] # the ordering of the colors indicate the latest available refdate
-REFDATE_LINEWIDTH = [1, 1.1, 1.2, 1.3, 1.5]
 
-
-def iwv_itcz_edges_ens(
+def iwv_itcz_edges_enfo(
     briefing_time: pd.Timestamp,
     lead_hours: str,
     current_time: pd.Timestamp,
@@ -54,6 +46,9 @@ def iwv_itcz_edges_ens(
         forecast_type="enfo"
     )
     _validate_issue_times(issue_time_oper, issue_time_enfo)
+    climatology = _get_rolling_daily_climatology(
+        ICWV_CATALOG_VARIABLE, briefing_time, lead_hours
+        )
     # plot
     sns.set_context("talk")
     fig, ax = plt.subplots(
@@ -61,10 +56,11 @@ def iwv_itcz_edges_ens(
         subplot_kw={"projection": ccrs.PlateCarree()}
     )
     format_internal_figure_axes(briefing_time, lead_hours, issue_time_oper,
-                                sattracks_fc_time, ax)
-    _draw_icwv_enfo_contours(forecast_enfo, ax)
-    _draw_icwv_enfo_mean_contour(forecast_enfo, ax)
-    _draw_icwv_oper_contour(forecast_oper, ax)
+                                sattracks_fc_time, "iwv_itcz_edges_enfo", ax)
+    plot1 = _draw_icwv_enfo_contours(forecast_enfo, ax)
+    plot2 = _draw_icwv_enfo_mean_contour(forecast_enfo, ax)
+    plot3 = _draw_icwv_oper_contour(forecast_oper, ax)
+    plot4 = _draw_icwv_ERA5_contour(climatology, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,
                   which_orbit="descending")
     for flight_id in FLIGHTS:
@@ -73,12 +69,15 @@ def iwv_itcz_edges_ens(
                                 color="C1", show_waypoints=False)
     plot_meteor_latest_position_in_ifs_forecast(
         briefing_time, lead_hours, ax, meteor=meteor_track)
+    
+    handles = [plot1, plot2, plot3, plot4]
+    plt.legend(handles=handles, fontsize=8, loc="lower left", frameon=False)
     matplotlib.rc_file_defaults()
     return fig
 
 
 def _validate_issue_times(
-        issue_time_oper: pd.Timestamp, issue_time_enfo):
+        issue_time_oper: pd.Timestamp, issue_time_enfo: pd.Timestamp):
     """Give a warning if issue times of operational forecast and ensemble
     forecast disagree."""
     msg = (f"WARNING: Issue times of operational forecast and ensemble " +
@@ -100,7 +99,9 @@ def _draw_icwv_oper_contour(forecast, ax):
         colors=color,
         linewidths=linewidth,
     )
-
+    line = Line2D([0], [0], label="Operational forecast", color=color,
+                  linewidth=linewidth)
+    return line
 
 def _draw_icwv_enfo_contours(forecasts, ax):
     color = "#bf0000"
@@ -115,11 +116,14 @@ def _draw_icwv_enfo_contours(forecasts, ax):
             linewidths=linewidth,
             alpha=alpha,
         )
+    line = Line2D([0], [0], label="Individual ensemble members", color=color,
+                  linewidth=linewidth, alpha=alpha)
+    return line
 
 
 def _draw_icwv_enfo_mean_contour(forecasts, ax):
-    color = "#800000",
-    linewidth = 2.0,
+    color = "#800000"
+    linewidth = 2.0
     enfo_mean = forecasts.mean(dim="member")
     egh.healpix_contour(
         enfo_mean,
@@ -128,6 +132,48 @@ def _draw_icwv_enfo_mean_contour(forecasts, ax):
         colors=color,
         linewidths=linewidth,
     )
+    line = Line2D([0], [0], label="Ensemble mean", color=color,
+                  linewidth=linewidth)
+    return line
+
+
+def _draw_icwv_ERA5_contour(climatology, ax):
+    color = "gray"
+    linewidth = 2.0
+    ls = '--'
+    #cat = intake.open_catalog("https://tcodata.mpimet.mpg.de/internal.yaml")
+    #hera5 = cat.HERA5.to_dask().pipe(egh.attach_coords)["tcwv"]
+    #augsep_clim = hera5.sel(
+    #    time=hera5['time'].dt.month.isin([8, 9])).mean(dim="time")
+    egh.healpix_contour(
+        climatology,
+        ax=ax,
+        levels=[ICWV_ITCZ_THRESHOLD],
+        colors=color,
+        linewidths=linewidth,
+        linestyles=ls,
+    )
+    line = Line2D([0], [0], label="ERA5 2010-2022 7-day running mean",
+                  color=color, linewidth=linewidth)
+    return line
+
+def _get_rolling_daily_climatology(
+        var: str,
+        briefing_time: pd.Timestamp,
+        lead_hours: str):
+    valid_time = get_valid_time(briefing_time, lead_hours)
+    valid_time_doy = valid_time.day_of_year
+    climatology = _load_rolling_daily_climatology(var)
+    return climatology.sel(dayofyear=valid_time_doy)
+
+def _load_rolling_daily_climatology(var: str="tcwv"):
+    cat = intake.open_catalog("https://tcodata.mpimet.mpg.de/internal.yaml")
+    hera5 = cat.HERA5(time="P1D").to_dask().pipe(egh.attach_coords)[var]
+    hera5_subsample = hera5.where(
+        hera5["time"] < np.datetime64("2023-01-01"), drop=True
+        )
+    hera5_running_mean = hera5_subsample.rolling(time=7, center=True).mean()
+    return hera5_running_mean.groupby('time.dayofyear').mean()
 
 
 if __name__ == "__main__":
@@ -141,6 +187,6 @@ if __name__ == "__main__":
     current_time1 = pd.Timestamp(2024, 8, 31, 10).tz_localize("UTC")
     sattracks_fc_time1 = pd.Timestamp(2024, 8, 31).tz_localize("UTC")
     meteor_track = get_meteor_track(deduplicate_latlon=True)
-    fig = iwv_itcz_edges_ens(briefing_time1, "12H", current_time1,
-                         sattracks_fc_time1, meteor_track, hifs)
+    fig = iwv_itcz_edges_enfo(briefing_time1, "12H", current_time1,
+                              sattracks_fc_time1, meteor_track, hifs)
     fig.savefig("test_icwv_enfo.png")

--- a/src/wblib/figures/internal/icwv_ens.py
+++ b/src/wblib/figures/internal/icwv_ens.py
@@ -130,15 +130,6 @@ def _draw_icwv_enfo_mean_contour(forecasts, ax):
     )
 
 
-    egh.healpix_contour(
-        enfo_mean,
-        ax=ax,
-        levels=[ICWV_ITCZ_THRESHOLD],
-        colors=color,
-        linewidths=linewidth,
-    )
-
-
 if __name__ == "__main__":
     import intake
     from orcestra.meteor import get_meteor_track

--- a/src/wblib/figures/internal/precip.py
+++ b/src/wblib/figures/internal/precip.py
@@ -72,7 +72,7 @@ def precip(
         subplot_kw={"projection": ccrs.PlateCarree()}
     )
     format_internal_figure_axes(briefing_time, lead_hours, issue_time,
-                                sattracks_fc_time, ax)
+                                sattracks_fc_time, "precip", ax)
     _draw_tcwv_contours_for_previous_forecasts(tcwv_forecasts, ax)
     _draw_current_forecast(precip, fig, ax)
     plot_sattrack(ax, briefing_time, lead_hours, sattracks_fc_time,

--- a/src/wblib/figures/internal/sfc_winds.py
+++ b/src/wblib/figures/internal/sfc_winds.py
@@ -51,7 +51,7 @@ def sfc_winds(
         facecolor="white",
     )
     format_internal_figure_axes(briefing_time, lead_hours, issue_time,
-                                sattracks_fc_time, ax)
+                                sattracks_fc_time, "sfc_winds", ax)
     _windspeed_plot(windspeed_10m, fig, ax)
     _wind_direction_plot(u10m, v10m, ax)
     _windspeed_contour(windspeed_10m, ax)

--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -12,6 +12,7 @@ from wblib.figures.internal.icwv import iwv_itcz_edges
 from wblib.figures.internal.sfc_winds import sfc_winds
 from wblib.figures.internal.precip import precip
 from wblib.figures.internal.cld_top_height import cloud_top_height
+from wblib.figures.internal.icwv_ens import iwv_itcz_edges_enfo
 
 EXTERNAL_INST_PLOTS = {
     "nhc_surface_analysis_atlantic": nhc_surface_analysis_atlantic,
@@ -32,6 +33,7 @@ INTERNAL_PLOTS = {
     "sfc_winds": sfc_winds,
     "precip": precip,
     "cloud_top_height": cloud_top_height,
+    "iwv_itcz_edges_enfo": iwv_itcz_edges_enfo,
 }
 
 PLOTS_LEADTIMES = ["012h", "036h", "060h", "084h", "108h"]

--- a/src/wblib/services/get_expected_figures_yaml.py
+++ b/src/wblib/services/get_expected_figures_yaml.py
@@ -9,7 +9,6 @@ from wblib.services._define_figures import EXTERNAL_LEAD_PLOTS
 from wblib.services._define_figures import INTERNAL_PLOTS
 from wblib.services._define_figures import PLOTS_LEADTIMES
 
-MSS_PLOTS_SIDE_VIEW = ["relative_humidity", "cloud_cover"]
 ALLOWED_LOCATIONS = ["Barbados", "Sal"]
 
 

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -77,6 +77,15 @@ NHC tropical Hovmöller
 ![]({{< meta plots.internal.precip.108h >}}){width=42%}
 :::
 
+## 
+### Ensemble forecasts of moist margins
+::: {layout-nrow=2}
+![{{< meta valid_dates.012h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.012h >}}){width=42%}
+![{{< meta valid_dates.036h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.036h >}}){width=42%}
+![{{< meta valid_dates.060h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.060h >}}){width=42%}
+![{{< meta valid_dates.084h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.084h >}}){width=42%}
+:::
+
 # Saharan dust forecast
 ##
 :::: {.columns}


### PR DESCRIPTION
This MR adds the spaghetti plot of the ICWV 48mm contour based on the IFS ensemble forecast, after @lkluft implemented its operational download. Furthermore, the spaghetti plots includes the daily climatology of the 48mm ICWV contour based on a 7-day running mean from ERA5 data (averaged over 2010 to 2022). Please see the example plot attached.
I currently added the spaghetti plots on an additional slide in the weather briefing, which comes after the internal forecast slides. The structure of this slide is like the dust plots.
As the annotation box had to be adjusted in the spaghetti plots, I took the chance to make the annotation box plot-dependent in general. Therefore, also the sfc_winds plot has now a more accurate annotation box, which addresses issue #147.

The additional infrastructure to load the ERA5 climatology is not very advanced yet and should potentially be put into a separate file instead of being located within `icwv_ens.py`. However, this refactoring should be addressed in a separate issue.
Furthermore, the download of the climatological data is rather slow due to the large amount of data. Therefore, it would make sense to load both, the ERA5 data as well as the forecast data not within each plot, but once before the generation of all plots. This has the potential to save a lot of time during generating the briefing as it would avoid redundant loading of the same datasets. However, also this should be addressed in a separate issue. For now, please note that generating the briefing becomes longer by about 10 minutes due to the new spaghetti plots (FYI @karstenpeters, @sortega87, @Lucalino).

![test_icwv_enfo](https://github.com/user-attachments/assets/e12cea44-cc33-4840-bc70-da0c350cfb5e)