### PR TITLE
Adjust leadtimes

### DIFF
--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -37,4 +37,4 @@ INTERNAL_PLOTS = {
     "iwv_itcz_edges_enfo": iwv_itcz_edges_enfo,
 }
 
-PLOTS_LEADTIMES = ["012h", "036h", "060h", "084h", "108h"]
+PLOTS_LEADTIMES = ["015h", "039h", "063h", "087h", "108h"]

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -33,39 +33,39 @@ NHC tropical Hovmöller
 # ECMWF Forecasts
 
 ## 
-### {{< meta valid_dates.012h >}}
+### {{< meta valid_dates.015h >}}
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.012h >}}){width=42%}
-![]({{< meta plots.internal.sfc_winds.012h >}}){width=42%}
-![]({{< meta plots.internal.cloud_top_height.012h >}}){width=42%}
-![]({{< meta plots.internal.precip.012h >}}){width=42%}
+![]({{< meta plots.internal.iwv_itcz_edges.015h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.015h >}}){width=42%}
+![]({{< meta plots.internal.cloud_top_height.015h >}}){width=42%}
+![]({{< meta plots.internal.precip.015h >}}){width=42%}
 :::
 
 ## 
-### {{< meta valid_dates.036h >}}
+### {{< meta valid_dates.039h >}}
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.036h >}}){width=42%}
-![]({{< meta plots.internal.sfc_winds.036h >}}){width=42%}
-![]({{< meta plots.internal.cloud_top_height.036h >}}){width=42%}
-![]({{< meta plots.internal.precip.036h >}}){width=42%}
+![]({{< meta plots.internal.iwv_itcz_edges.039h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.039h >}}){width=42%}
+![]({{< meta plots.internal.cloud_top_height.039h >}}){width=42%}
+![]({{< meta plots.internal.precip.039h >}}){width=42%}
 :::
 
 ## 
-### {{< meta valid_dates.060h >}}
+### {{< meta valid_dates.063h >}}
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.060h >}}){width=42%}
-![]({{< meta plots.internal.sfc_winds.060h >}}){width=42%}
-![]({{< meta plots.internal.cloud_top_height.060h >}}){width=42%}
-![]({{< meta plots.internal.precip.060h >}}){width=42%}
+![]({{< meta plots.internal.iwv_itcz_edges.063h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.063h >}}){width=42%}
+![]({{< meta plots.internal.cloud_top_height.063h >}}){width=42%}
+![]({{< meta plots.internal.precip.063h >}}){width=42%}
 :::
 
 ## 
-### {{< meta valid_dates.084h >}}
+### {{< meta valid_dates.087h >}}
 ::: {layout-nrow=2}
-![]({{< meta plots.internal.iwv_itcz_edges.084h >}}){width=42%}
-![]({{< meta plots.internal.sfc_winds.084h >}}){width=42%}
-![]({{< meta plots.internal.cloud_top_height.084h >}}){width=42%}
-![]({{< meta plots.internal.precip.084h >}}){width=42%}
+![]({{< meta plots.internal.iwv_itcz_edges.087h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.087h >}}){width=42%}
+![]({{< meta plots.internal.cloud_top_height.087h >}}){width=42%}
+![]({{< meta plots.internal.precip.087h >}}){width=42%}
 :::
 
 ## 
@@ -80,10 +80,10 @@ NHC tropical Hovmöller
 ## 
 ### Ensemble forecasts of moist margins
 ::: {layout-nrow=2}
-![{{< meta valid_dates.012h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.012h >}}){width=42%}
-![{{< meta valid_dates.036h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.036h >}}){width=42%}
-![{{< meta valid_dates.060h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.060h >}}){width=42%}
-![{{< meta valid_dates.084h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.084h >}}){width=42%}
+![{{< meta valid_dates.015h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.015h >}}){width=42%}
+![{{< meta valid_dates.039h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.039h >}}){width=42%}
+![{{< meta valid_dates.063h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.063h >}}){width=42%}
+![{{< meta valid_dates.087h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.087h >}}){width=42%}
 :::
 
 # Total aerosol optical depth
@@ -91,13 +91,13 @@ NHC tropical Hovmöller
 :::: {.columns}
 ::: {.column  width="93%"}
 ::: {layout-nrow=2}
-![{{< meta valid_dates.012h >}}]({{< meta plots.external_lead.total_aerosol.012h >}}){width=75%}
+![{{< meta valid_dates.015h >}}]({{< meta plots.external_lead.total_aerosol.015h >}}){width=75%}
 
-![{{< meta valid_dates.036h >}}]({{< meta plots.external_lead.total_aerosol.036h >}}){width=75%}
+![{{< meta valid_dates.039h >}}]({{< meta plots.external_lead.total_aerosol.039h >}}){width=75%}
 
-![{{< meta valid_dates.060h >}}]({{< meta plots.external_lead.total_aerosol.060h >}}){width=75%}
+![{{< meta valid_dates.063h >}}]({{< meta plots.external_lead.total_aerosol.063h >}}){width=75%}
 
-![{{< meta valid_dates.084h >}}]({{< meta plots.external_lead.total_aerosol.084h >}}){width=75%}
+![{{< meta valid_dates.087h >}}]({{< meta plots.external_lead.total_aerosol.087h >}}){width=75%}
 :::
 :::
 ::: {.column width="7%"}


### PR DESCRIPTION
This MR adjusts the valid times of the shown forecasts from 1200UTC to 1500UTC of a specific day to account for the local time of Barbados being UTC-4. This was agreed up on by Julia and Silke.
Unfortunately, ECMWF only provides its forecast with a 3-hourly granularity up to lead hour +90. Thus, for the 5th forecast day we have to stick with the forecast for 12UTC of that day as for some of the older forecasts we show in the contour lines this corresponds to lead hours >+90h.