### PR TITLE
Add 108h and 132h lead times for internal figures.

### DIFF
--- a/src/wblib/services/_define_figures.py
+++ b/src/wblib/services/_define_figures.py
@@ -37,4 +37,4 @@ INTERNAL_PLOTS = {
     "iwv_itcz_edges_enfo": iwv_itcz_edges_enfo,
 }
 
-PLOTS_LEADTIMES = ["015h", "039h", "063h", "084h", "108h"]
+PLOTS_LEADTIMES = ["015h", "039h", "063h", "084h", "108h", "132h"]

--- a/src/wblib/template.qmd
+++ b/src/wblib/template.qmd
@@ -78,6 +78,15 @@ NHC tropical Hovmöller
 :::
 
 ## 
+### {{< meta valid_dates.132h >}}
+::: {layout-nrow=2}
+![]({{< meta plots.internal.iwv_itcz_edges.132h >}}){width=42%}
+![]({{< meta plots.internal.sfc_winds.132h >}}){width=42%}
+![]({{< meta plots.internal.cloud_top_height.132h >}}){width=42%}
+![]({{< meta plots.internal.precip.132h >}}){width=42%}
+:::
+
+## 
 ### Ensemble forecasts of moist margins
 ::: {layout-nrow=2}
 ![{{< meta valid_dates.015h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.015h >}}){width=42%}
@@ -86,17 +95,21 @@ NHC tropical Hovmöller
 ![{{< meta valid_dates.084h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.084h >}}){width=42%}
 :::
 
+## 
+### Ensemble forecasts of moist margins
+::: {layout-nrow=2}
+![{{< meta valid_dates.015h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.108h >}}){width=42%}
+![{{< meta valid_dates.015h >}}]({{< meta plots.internal.iwv_itcz_edges_enfo.132h >}}){width=42%}
+:::
+
 # Total aerosol optical depth
 ##
 :::: {.columns}
 ::: {.column  width="93%"}
 ::: {layout-nrow=2}
 ![{{< meta valid_dates.015h >}}]({{< meta plots.external_lead.total_aerosol.015h >}}){width=75%}
-
 ![{{< meta valid_dates.039h >}}]({{< meta plots.external_lead.total_aerosol.039h >}}){width=75%}
-
 ![{{< meta valid_dates.063h >}}]({{< meta plots.external_lead.total_aerosol.063h >}}){width=75%}
-
 ![{{< meta valid_dates.084h >}}]({{< meta plots.external_lead.total_aerosol.084h >}}){width=75%}
 :::
 :::
@@ -104,6 +117,7 @@ NHC tropical Hovmöller
 ![](dust_colorbar.png){width=100%}
 :::
 ::::
+
 
 ##
 :::: {.columns}


### PR DESCRIPTION
I increased the lead time by one day and added internal plots for lead time 108h and 132h to the template. 
While the internal plots render just fine, the aerosol plots for which I would, in principle, like to include the 108h forecast, are broken, even though I haven't really changed anything about them in the template (the removal of empty lines does not seem to have an effect).