### PR TITLE
Fix of requesting the non-existing lead time +132h

### DIFF
--- a/src/wblib/services/get_figures.py
+++ b/src/wblib/services/get_figures.py
@@ -17,6 +17,7 @@ from wblib.services._define_figures import PLOTS_LEADTIMES
 Image = Union[img.Image, Figure]
 
 INTAKE_CATALOG_URL = "https://tcodata.mpimet.mpg.de/internal.yaml"
+MAX_LEAD_TIME_EXTERNAL_LEAD = 120   #[h]
 
 def generate_external_inst_figures(
     current_location: str,
@@ -60,6 +61,8 @@ def generate_external_lead_figures(
             _warn_function_is_not_defined(product, logger)
             continue
         for lead_hours in PLOTS_LEADTIMES:
+            if int(lead_hours[:-1]) > MAX_LEAD_TIME_EXTERNAL_LEAD:
+                continue
             try:
                 figure = function(
                     briefing_time,


### PR DESCRIPTION
With #202 we added lead hour `+132h` to the briefing. However, ECMWF only provides EC Charts for aerosol AOD up to lead hour `+120h`. Thus, requesting the total aerosol AOD for `+132h` threw an error, which can lead to the wrong impression that something with the briefing itself is broken. With this fix, plots for lead hours larger than `+120h` are no longer requested.