### PR TITLE
Revert "Ensemble forecast quick fix (#232)"

### DIFF
--- a/src/wblib/figures/hifs.py
+++ b/src/wblib/figures/hifs.py
@@ -93,8 +93,6 @@ class HifsForecasts:
         differentiate,
         differentiate_unit,
     ) -> tuple[pd.Timestamp, xr.DataArray]:
-        if variable == "tcwv" and forecast_type == "enfo":
-            variable = "avg_tcwv"
         issue_time, forecast_dataset = _load_forecast_dataset(
             briefing_time, current_time, forecast_type, self.catalog
         )


### PR DESCRIPTION
This reverts commit 5f1673e4a028b351fd993aedfb8326740c91fee8 as the ensemble data seems to output now the same variables as before.